### PR TITLE
Add basic Line decoder implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .DS_Store
+TODOs.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,8 @@ strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0"
 
 [dev-dependencies]
+geo = "0.30"
 geojson = "0.24"
+graph = "0.3"
+rstar = "0.12"
 test-log = { version = "0.2", features = ["trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ categories = ["encoding"]
 [dependencies]
 approx = "0.5"
 base64 = "0.22"
+ordered-float = "5.0"
+strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ base64 = "0.22"
 ordered-float = "5.0"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0"
+
+[dev-dependencies]
+geojson = "0.24"
+test-log = { version = "0.2", features = ["trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22"
 ordered-float = "5.0"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0"
+tracing = "0.1"
 
 [dev-dependencies]
 geo = "0.30"

--- a/src/binary/encoding.rs
+++ b/src/binary/encoding.rs
@@ -160,25 +160,25 @@ impl Length {
 
     /// Returns the distance to next LR-point in meters from a byte.
     pub(crate) fn dnp_from_byte(byte: u8) -> Self {
-        let meters = ((byte as f64 + 0.5) * Self::DISTANCE_PER_INTERVAL).round() as u32;
+        let meters = ((byte as f64 + 0.5) * Self::DISTANCE_PER_INTERVAL).round();
         Self::from_meters(meters)
     }
 
     /// Returns the distance to next LR-point interval.
     pub(crate) fn dnp_into_byte(self) -> u8 {
-        (self.meters() as f64 / Self::DISTANCE_PER_INTERVAL - 0.5).round() as u8
+        (self.meters() / Self::DISTANCE_PER_INTERVAL - 0.5).round() as u8
     }
 
     /// Returns the length of a radius in meters from big-endian slice of (up to 4) bytes.
     pub(crate) fn radius_from_be_bytes(bytes: &[u8]) -> Self {
         let mut radius = [0u8; 4];
         radius[4 - bytes.len()..].copy_from_slice(bytes);
-        Self::from_meters(u32::from_be_bytes(radius))
+        Self::from_meters(u32::from_be_bytes(radius) as f64)
     }
 
     /// Returns the big-endian representation of a radius in 4 bytes.
     pub(crate) fn radius_into_be_bytes(self) -> [u8; 4] {
-        u32::to_be_bytes(self.meters())
+        u32::to_be_bytes(self.meters() as u32)
     }
 }
 
@@ -198,8 +198,8 @@ impl Bearing {
             return Err(SerializeError::InvalidBearing(degrees));
         }
 
-        let bear = (degrees as f64 - Self::BEAR_SECTOR / 2.0) / Self::BEAR_SECTOR;
-        Ok(bear.round() as u8)
+        let bearing = (degrees as f64 - Self::BEAR_SECTOR / 2.0) / Self::BEAR_SECTOR;
+        Ok(bearing.round() as u8)
     }
 }
 

--- a/src/binary/encoding.rs
+++ b/src/binary/encoding.rs
@@ -307,6 +307,7 @@ const fn signum(value: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use approx::assert_relative_eq;
+    use test_log::test;
 
     use super::*;
 

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -330,6 +330,8 @@ impl<'a> OpenLrBinaryReader<'a> {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::model::Offsets;
     use crate::{Orientation, SideOfRoad};

--- a/src/binary/reader.rs
+++ b/src/binary/reader.rs
@@ -293,11 +293,11 @@ impl<'a> OpenLrBinaryReader<'a> {
         let fow = Fow::try_from_byte(attributes[0] & 0b111)?;
         let frc = Frc::try_from_byte((attributes[0] >> 3) & 0b111)?;
         let orientation_or_side = (attributes[0] >> 6) & 0b11;
-        let bear = Bearing::from_byte(attributes[1] & 0b11111);
+        let bearing = Bearing::from_byte(attributes[1] & 0b11111);
         let lfrcnp_or_flags = (attributes[1] >> 5) & 0b111;
 
         Ok(EncodedAttributes {
-            line: LineAttributes { frc, fow, bear },
+            line: LineAttributes { frc, fow, bearing },
             lfrcnp_or_flags,
             orientation_or_side,
         })
@@ -374,11 +374,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(141)
+                            bearing: Bearing::from_degrees(141)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc3,
-                            dnp: Length::from_meters(557)
+                            dnp: Length::from_meters(557.0)
                         })
                     },
                     Point {
@@ -389,11 +389,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(231)
+                            bearing: Bearing::from_degrees(231)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc5,
-                            dnp: Length::from_meters(264)
+                            dnp: Length::from_meters(264.0)
                         })
                     },
                     Point {
@@ -404,7 +404,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc5,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(287)
+                            bearing: Bearing::from_degrees(287)
                         },
                         path: None
                     }
@@ -433,11 +433,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::Roundabout,
-                            bear: Bearing::from_degrees(28)
+                            bearing: Bearing::from_degrees(28)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc3,
-                            dnp: Length::from_meters(498)
+                            dnp: Length::from_meters(498.0)
                         })
                     },
                     Point {
@@ -448,7 +448,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(197)
+                            bearing: Bearing::from_degrees(197)
                         },
                         path: None
                     },
@@ -477,11 +477,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc1,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(298)
+                            bearing: Bearing::from_degrees(298)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc1,
-                            dnp: Length::from_meters(88)
+                            dnp: Length::from_meters(88.0)
                         })
                     },
                     Point {
@@ -492,7 +492,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc1,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(298)
+                            bearing: Bearing::from_degrees(298)
                         },
                         path: None
                     },
@@ -518,11 +518,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(6)
+                            bearing: Bearing::from_degrees(6)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc3,
-                            dnp: Length::from_meters(29)
+                            dnp: Length::from_meters(29.0)
                         })
                     },
                     Point {
@@ -533,11 +533,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(6)
+                            bearing: Bearing::from_degrees(6)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc5,
-                            dnp: Length::from_meters(29)
+                            dnp: Length::from_meters(29.0)
                         })
                     },
                     Point {
@@ -548,7 +548,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc5,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(6)
+                            bearing: Bearing::from_degrees(6)
                         },
                         path: None
                     }
@@ -600,11 +600,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc2,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(73)
+                            bearing: Bearing::from_degrees(73)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc2,
-                            dnp: Length::from_meters(1436)
+                            dnp: Length::from_meters(1436.0)
                         })
                     },
                     Point {
@@ -615,7 +615,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc2,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(219)
+                            bearing: Bearing::from_degrees(219)
                         },
                         path: None
                     }
@@ -643,11 +643,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc2,
                             fow: Fow::Roundabout,
-                            bear: Bearing::from_degrees(264)
+                            bearing: Bearing::from_degrees(264)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc2,
-                            dnp: Length::from_meters(88)
+                            dnp: Length::from_meters(88.0)
                         })
                     },
                     Point {
@@ -658,7 +658,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc2,
                             fow: Fow::Roundabout,
-                            bear: Bearing::from_degrees(321)
+                            bearing: Bearing::from_degrees(321)
                         },
                         path: None
                     }
@@ -687,11 +687,11 @@ mod tests {
                             line: LineAttributes {
                                 frc: Frc::Frc4,
                                 fow: Fow::SingleCarriageway,
-                                bear: Bearing::from_degrees(219)
+                                bearing: Bearing::from_degrees(219)
                             },
                             path: Some(PathAttributes {
                                 lfrcnp: Frc::Frc4,
-                                dnp: Length::from_meters(147)
+                                dnp: Length::from_meters(147.0)
                             })
                         },
                         Point {
@@ -702,7 +702,7 @@ mod tests {
                             line: LineAttributes {
                                 frc: Frc::Frc4,
                                 fow: Fow::SingleCarriageway,
-                                bear: Bearing::from_degrees(39)
+                                bearing: Bearing::from_degrees(39)
                             },
                             path: None
                         }
@@ -730,7 +730,7 @@ mod tests {
                     lon: 5.101_851,
                     lat: 52.105_976
                 },
-                radius: Length::from_meters(300)
+                radius: Length::from_meters(300.0)
             })
         );
     }
@@ -746,7 +746,7 @@ mod tests {
                     lon: -3.3115947,
                     lat: 55.945_29
                 },
-                radius: Length::from_meters(2000)
+                radius: Length::from_meters(2000.0)
             })
         );
     }
@@ -884,11 +884,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc2,
                             fow: Fow::MultipleCarriageway,
-                            bear: Bearing::from_degrees(129)
+                            bearing: Bearing::from_degrees(129)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc3,
-                            dnp: Length::from_meters(264)
+                            dnp: Length::from_meters(264.0)
                         })
                     },
                     Point {
@@ -899,18 +899,18 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc3,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(231)
+                            bearing: Bearing::from_degrees(231)
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc7,
-                            dnp: Length::from_meters(498)
+                            dnp: Length::from_meters(498.0)
                         })
                     },
                 ],
                 last_line: LineAttributes {
                     frc: Frc::Frc2,
                     fow: Fow::SingleCarriageway,
-                    bear: Bearing::from_degrees(242)
+                    bearing: Bearing::from_degrees(242)
                 }
             })
         );

--- a/src/binary/writer.rs
+++ b/src/binary/writer.rs
@@ -237,10 +237,10 @@ impl OpenLrBinaryWriter {
     fn write_attributes(&mut self, attributes: EncodedAttributes) -> Result<(), SerializeError> {
         let fow = attributes.line.fow.into_byte();
         let frc = attributes.line.frc.into_byte();
-        let bear = attributes.line.bear.try_into_byte()?;
+        let bearing = attributes.line.bearing.try_into_byte()?;
 
         let first_byte = fow + (frc << 3) + (attributes.orientation_or_side << 6);
-        let second_byte = bear + (attributes.lfrcnp_or_flags << 5);
+        let second_byte = bearing + (attributes.lfrcnp_or_flags << 5);
         self.cursor.write_all(&[first_byte, second_byte])?;
         Ok(())
     }
@@ -291,11 +291,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(141),
+                        bearing: Bearing::from_degrees(141),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc3,
-                        dnp: Length::from_meters(557),
+                        dnp: Length::from_meters(557.0),
                     }),
                 },
                 Point {
@@ -306,11 +306,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(231),
+                        bearing: Bearing::from_degrees(231),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc5,
-                        dnp: Length::from_meters(264),
+                        dnp: Length::from_meters(264.0),
                     }),
                 },
                 Point {
@@ -321,7 +321,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc5,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(287),
+                        bearing: Bearing::from_degrees(287),
                     },
                     path: None,
                 },
@@ -345,11 +345,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::Roundabout,
-                        bear: Bearing::from_degrees(28),
+                        bearing: Bearing::from_degrees(28),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc3,
-                        dnp: Length::from_meters(498),
+                        dnp: Length::from_meters(498.0),
                     }),
                 },
                 Point {
@@ -360,7 +360,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(197),
+                        bearing: Bearing::from_degrees(197),
                     },
                     path: None,
                 },
@@ -384,11 +384,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc1,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(298),
+                        bearing: Bearing::from_degrees(298),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc1,
-                        dnp: Length::from_meters(88),
+                        dnp: Length::from_meters(88.0),
                     }),
                 },
                 Point {
@@ -399,7 +399,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc1,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(298),
+                        bearing: Bearing::from_degrees(298),
                     },
                     path: None,
                 },
@@ -420,11 +420,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(6),
+                        bearing: Bearing::from_degrees(6),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc3,
-                        dnp: Length::from_meters(29),
+                        dnp: Length::from_meters(29.0),
                     }),
                 },
                 Point {
@@ -435,11 +435,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(6),
+                        bearing: Bearing::from_degrees(6),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc5,
-                        dnp: Length::from_meters(29),
+                        dnp: Length::from_meters(29.0),
                     }),
                 },
                 Point {
@@ -450,7 +450,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc5,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(6),
+                        bearing: Bearing::from_degrees(6),
                     },
                     path: None,
                 },
@@ -471,11 +471,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc1,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(298),
+                        bearing: Bearing::from_degrees(298),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc1,
-                        dnp: Length::from_meters(88),
+                        dnp: Length::from_meters(88.0),
                     }),
                 },
                 Point {
@@ -486,7 +486,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc1,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(298),
+                        bearing: Bearing::from_degrees(298),
                     },
                     path: None,
                 },
@@ -547,11 +547,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc2,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(73),
+                        bearing: Bearing::from_degrees(73),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc2,
-                        dnp: Length::from_meters(1436),
+                        dnp: Length::from_meters(1436.0),
                     }),
                 },
                 Point {
@@ -562,7 +562,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc2,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(219),
+                        bearing: Bearing::from_degrees(219),
                     },
                     path: None,
                 },
@@ -585,11 +585,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc2,
                         fow: Fow::Roundabout,
-                        bear: Bearing::from_degrees(264),
+                        bearing: Bearing::from_degrees(264),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc4,
-                        dnp: Length::from_meters(88),
+                        dnp: Length::from_meters(88.0),
                     }),
                 },
                 Point {
@@ -600,7 +600,7 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc2,
                         fow: Fow::Roundabout,
-                        bear: Bearing::from_degrees(321),
+                        bearing: Bearing::from_degrees(321),
                     },
                     path: None,
                 },
@@ -624,11 +624,11 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc4,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(219),
+                            bearing: Bearing::from_degrees(219),
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc4,
-                            dnp: Length::from_meters(147),
+                            dnp: Length::from_meters(147.0),
                         }),
                     },
                     Point {
@@ -639,7 +639,7 @@ mod tests {
                         line: LineAttributes {
                             frc: Frc::Frc4,
                             fow: Fow::SingleCarriageway,
-                            bear: Bearing::from_degrees(39),
+                            bearing: Bearing::from_degrees(39),
                         },
                         path: None,
                     },
@@ -662,7 +662,7 @@ mod tests {
                 lon: 5.1018512,
                 lat: 52.1059763,
             },
-            radius: Length::from_meters(300),
+            radius: Length::from_meters(300.0),
         }));
     }
 
@@ -673,7 +673,7 @@ mod tests {
                 lon: -3.3115947,
                 lat: 55.9452903,
             },
-            radius: Length::from_meters(2000),
+            radius: Length::from_meters(2000.0),
         }));
     }
 
@@ -781,11 +781,11 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc2,
                         fow: Fow::MultipleCarriageway,
-                        bear: Bearing::from_degrees(129),
+                        bearing: Bearing::from_degrees(129),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc3,
-                        dnp: Length::from_meters(264),
+                        dnp: Length::from_meters(264.0),
                     }),
                 },
                 Point {
@@ -796,18 +796,18 @@ mod tests {
                     line: LineAttributes {
                         frc: Frc::Frc3,
                         fow: Fow::SingleCarriageway,
-                        bear: Bearing::from_degrees(231),
+                        bearing: Bearing::from_degrees(231),
                     },
                     path: Some(PathAttributes {
                         lfrcnp: Frc::Frc7,
-                        dnp: Length::from_meters(498),
+                        dnp: Length::from_meters(498.0),
                     }),
                 },
             ],
             last_line: LineAttributes {
                 frc: Frc::Frc2,
                 fow: Fow::SingleCarriageway,
-                bear: Bearing::from_degrees(242),
+                bearing: Bearing::from_degrees(242),
             },
         }));
     }

--- a/src/binary/writer.rs
+++ b/src/binary/writer.rs
@@ -272,6 +272,8 @@ impl OpenLrBinaryWriter {
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::model::Offsets;
     use crate::{

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -27,12 +27,16 @@ use crate::{
 pub struct DecoderConfig {
     /// Maximum distance from the LRP to the nodes of the graph that will be considered.
     pub max_node_distance: Length,
+    /// The length of the segment used to compute the lines bearing (distance from the start of
+    /// the segment to its end).
+    pub bearing_distance: Length,
 }
 
 impl Default for DecoderConfig {
     fn default() -> Self {
         Self {
             max_node_distance: Length::from_meters(100.0),
+            bearing_distance: Length::from_meters(20.0),
         }
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -9,32 +9,72 @@
 //! 6. Check validity of the calculated shortest-path(s).
 //! 7. Concatenate shortest-path(s) to form the location and trim path according to the offsets.
 
+pub mod candidates;
+
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
+use candidates::find_candidate_nodes;
+use tracing::info;
 
 use crate::error::DecodeError;
-use crate::{DeserializeError, DirectedGraph, Location, deserialize_binary_openlr};
+use crate::model::LineLocation;
+use crate::{
+    DeserializeError, DirectedGraph, Length, Line, Location, LocationReference,
+    deserialize_binary_openlr,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DecoderConfig {
+    /// Maximum distance from the LRP to the nodes of the graph that will be considered.
+    pub max_node_distance: Length,
+}
+
+impl Default for DecoderConfig {
+    fn default() -> Self {
+        Self {
+            max_node_distance: Length::from_meters(100.0),
+        }
+    }
+}
 
 /// Decodes an OpenLR Location Reference encoded in Base64.
 pub fn decode_base64_openlr<G: DirectedGraph>(
+    config: &DecoderConfig,
     graph: &G,
     data: impl AsRef<[u8]>,
 ) -> Result<Location, DecodeError> {
     let data = BASE64_STANDARD
         .decode(data)
         .map_err(DeserializeError::from)?;
-    decode_binary_openlr(graph, &data)
+    decode_binary_openlr(config, graph, &data)
 }
 
 /// Decodes an OpenLR Location Reference encoded in binary.
 pub fn decode_binary_openlr<G: DirectedGraph>(
-    _graph: &G,
+    config: &DecoderConfig,
+    graph: &G,
     data: &[u8],
 ) -> Result<Location, DecodeError> {
     // Step – 1 Decode physical data and check its validity
     let location = deserialize_binary_openlr(data)?;
 
-    Err(DecodeError::LocationTypeNotSupported(
-        location.location_type(),
-    ))
+    match location {
+        LocationReference::Line(line) => decode_line(config, graph, line).map(Location::Line),
+        _ => Err(DecodeError::LocationTypeNotSupported(
+            location.location_type(),
+        )),
+    }
+}
+
+fn decode_line<G: DirectedGraph>(
+    config: &DecoderConfig,
+    graph: &G,
+    line: Line,
+) -> Result<LineLocation, DecodeError> {
+    info!("Decoding {line:?} with {config:?}");
+
+    // Step – 2 For each location reference point find candidate nodes
+    let nodes = find_candidate_nodes(config, graph, &line.points);
+
+    todo!()
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -101,7 +101,7 @@ fn decode_line<G: DirectedGraph>(
     info!("Decoding {line:?} with {config:?}");
 
     // Step – 2 For each location reference point find candidate nodes
-    let nodes = find_candidate_nodes(config, graph, line.points.iter());
+    let nodes = find_candidate_nodes(config, graph, &line.points);
 
     // Step – 3 For each location reference point find candidate lines
     // Step – 4 Rate candidate lines for each location reference point
@@ -110,6 +110,9 @@ fn decode_line<G: DirectedGraph>(
     // Step – 5 Determine shortest-path(s) between all subsequent location reference points
     // Step – 6 Check validity of the calculated shortest-path(s)
     let routes = resolve_routes(config, graph, &lines)?;
+
+    // Step – 7 Concatenate shortest-path(s) to form the location
+    // and trim path according to the offsets
 
     todo!()
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -17,10 +17,10 @@ use candidates::find_candidate_nodes;
 use tracing::info;
 
 use crate::error::DecodeError;
-use crate::model::LineLocation;
+use crate::model::{LineLocation, RatingScore};
 use crate::{
-    DeserializeError, DirectedGraph, Length, Line, Location, LocationReference,
-    deserialize_binary_openlr,
+    Bearing, DeserializeError, DirectedGraph, Length, Line, Location, LocationReference,
+    deserialize_binary_openlr, find_candidate_lines,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -30,6 +30,15 @@ pub struct DecoderConfig {
     /// The length of the segment used to compute the lines bearing (distance from the start of
     /// the segment to its end).
     pub bearing_distance: Length,
+    /// Maximum bearing difference between the candidate line bearing and the LRP bearing for the
+    /// candidate to be accepted.
+    pub max_bearing_difference: Bearing,
+    /// Node weight applied by the rating function.
+    pub node_factor: f64,
+    /// Line weight applied by the rating function.
+    pub line_factor: f64,
+    /// Minimum rating score for a line to be accepted as candidate.
+    pub min_line_rating: RatingScore,
 }
 
 impl Default for DecoderConfig {
@@ -37,6 +46,10 @@ impl Default for DecoderConfig {
         Self {
             max_node_distance: Length::from_meters(100.0),
             bearing_distance: Length::from_meters(20.0),
+            max_bearing_difference: Bearing::from_degrees(90),
+            node_factor: 3.0,
+            line_factor: 3.0,
+            min_line_rating: RatingScore::from(800.0),
         }
     }
 }
@@ -78,7 +91,11 @@ fn decode_line<G: DirectedGraph>(
     info!("Decoding {line:?} with {config:?}");
 
     // Step – 2 For each location reference point find candidate nodes
-    let nodes = find_candidate_nodes(config, graph, &line.points);
+    let nodes = find_candidate_nodes(config, graph, line.points.iter());
+
+    // Step – 3 For each location reference point find candidate lines
+    // Step – 4 Rate candidate lines for each location reference point
+    let lines = find_candidate_lines(config, graph, nodes)?;
 
     todo!()
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,18 +10,17 @@
 //! 7. Concatenate shortest-path(s) to form the location and trim path according to the offsets.
 
 pub mod candidates;
+pub mod line;
 pub mod resolver;
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use candidates::find_candidate_nodes;
-use tracing::info;
 
 use crate::error::DecodeError;
-use crate::model::{LineLocation, RatingScore};
+use crate::model::RatingScore;
 use crate::{
-    Bearing, DeserializeError, DirectedGraph, Length, Line, Location, LocationReference,
-    deserialize_binary_openlr, find_candidate_lines, resolve_routes,
+    Bearing, DeserializeError, DirectedGraph, Length, Location, LocationReference, decode_line,
+    deserialize_binary_openlr,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -91,28 +90,4 @@ pub fn decode_binary_openlr<G: DirectedGraph>(
             location.location_type(),
         )),
     }
-}
-
-fn decode_line<G: DirectedGraph>(
-    config: &DecoderConfig,
-    graph: &G,
-    line: Line,
-) -> Result<LineLocation, DecodeError> {
-    info!("Decoding {line:?} with {config:?}");
-
-    // Step – 2 For each location reference point find candidate nodes
-    let nodes = find_candidate_nodes(config, graph, &line.points);
-
-    // Step – 3 For each location reference point find candidate lines
-    // Step – 4 Rate candidate lines for each location reference point
-    let lines = find_candidate_lines(config, graph, nodes)?;
-
-    // Step – 5 Determine shortest-path(s) between all subsequent location reference points
-    // Step – 6 Check validity of the calculated shortest-path(s)
-    let routes = resolve_routes(config, graph, &lines)?;
-
-    // Step – 7 Concatenate shortest-path(s) to form the location
-    // and trim path according to the offsets
-
-    todo!()
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,6 +10,7 @@
 //! 7. Concatenate shortest-path(s) to form the location and trim path according to the offsets.
 
 pub mod candidates;
+pub mod resolver;
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -42,6 +42,8 @@ pub struct DecoderConfig {
     pub projected_line_factor: f64,
     /// Minimum rating score for a line to be accepted as candidate.
     pub min_line_rating: RatingScore,
+    /// Maximum number of resolver retries.
+    pub max_number_retries: usize,
 }
 
 impl Default for DecoderConfig {
@@ -54,6 +56,7 @@ impl Default for DecoderConfig {
             line_factor: 3.0,
             projected_line_factor: 0.95,
             min_line_rating: RatingScore::from(800.0),
+            max_number_retries: 3,
         }
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -68,7 +68,7 @@ pub fn decode_base64_openlr<G: DirectedGraph>(
     config: &DecoderConfig,
     graph: &G,
     data: impl AsRef<[u8]>,
-) -> Result<Location, DecodeError> {
+) -> Result<Location<G::EdgeId>, DecodeError> {
     let data = BASE64_STANDARD
         .decode(data)
         .map_err(DeserializeError::from)?;
@@ -80,7 +80,7 @@ pub fn decode_binary_openlr<G: DirectedGraph>(
     config: &DecoderConfig,
     graph: &G,
     data: &[u8],
-) -> Result<Location, DecodeError> {
+) -> Result<Location<G::EdgeId>, DecodeError> {
     // Step – 1 Decode physical data and check its validity
     let location = deserialize_binary_openlr(data)?;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -21,7 +21,7 @@ use crate::error::DecodeError;
 use crate::model::{LineLocation, RatingScore};
 use crate::{
     Bearing, DeserializeError, DirectedGraph, Length, Line, Location, LocationReference,
-    deserialize_binary_openlr, find_candidate_lines,
+    deserialize_binary_openlr, find_candidate_lines, resolve_routes,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -44,6 +44,8 @@ pub struct DecoderConfig {
     pub min_line_rating: RatingScore,
     /// Maximum number of resolver retries.
     pub max_number_retries: usize,
+    /// Variance allowed to the resolver when computing distance between LRPs.
+    pub next_point_variance: Length,
 }
 
 impl Default for DecoderConfig {
@@ -57,6 +59,7 @@ impl Default for DecoderConfig {
             projected_line_factor: 0.95,
             min_line_rating: RatingScore::from(800.0),
             max_number_retries: 3,
+            next_point_variance: Length::from_meters(150.0),
         }
     }
 }
@@ -103,6 +106,10 @@ fn decode_line<G: DirectedGraph>(
     // Step – 3 For each location reference point find candidate lines
     // Step – 4 Rate candidate lines for each location reference point
     let lines = find_candidate_lines(config, graph, nodes)?;
+
+    // Step – 5 Determine shortest-path(s) between all subsequent location reference points
+    // Step – 6 Check validity of the calculated shortest-path(s)
+    let routes = resolve_routes(config, graph, &lines)?;
 
     todo!()
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -37,6 +37,8 @@ pub struct DecoderConfig {
     pub node_factor: f64,
     /// Line weight applied by the rating function.
     pub line_factor: f64,
+    /// Projected line weight applied by the rating function.
+    pub projected_line_factor: f64,
     /// Minimum rating score for a line to be accepted as candidate.
     pub min_line_rating: RatingScore,
 }
@@ -49,6 +51,7 @@ impl Default for DecoderConfig {
             max_bearing_difference: Bearing::from_degrees(90),
             node_factor: 3.0,
             line_factor: 3.0,
+            projected_line_factor: 0.95,
             min_line_rating: RatingScore::from(800.0),
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,40 @@
+//! The decoder resolves a (map-dependent) location using its own map.
+//! This map might differ from the one used during encoding.
+//!
+//! 1. Decode physical data and check its validity.
+//! 2. For each location reference point find candidate nodes.
+//! 3. For each location reference point find candidate lines.
+//! 4. Rate candidate lines for each location reference point.
+//! 5. Determine shortest-path(s) between two subsequent location reference points.
+//! 6. Check validity of the calculated shortest-path(s).
+//! 7. Concatenate shortest-path(s) to form the location and trim path according to the offsets.
+
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+
+use crate::error::DecodeError;
+use crate::{DeserializeError, DirectedGraph, Location, deserialize_binary_openlr};
+
+/// Decodes an OpenLR Location Reference encoded in Base64.
+pub fn decode_base64_openlr<G: DirectedGraph>(
+    graph: &G,
+    data: impl AsRef<[u8]>,
+) -> Result<Location, DecodeError> {
+    let data = BASE64_STANDARD
+        .decode(data)
+        .map_err(DeserializeError::from)?;
+    decode_binary_openlr(graph, &data)
+}
+
+/// Decodes an OpenLR Location Reference encoded in binary.
+pub fn decode_binary_openlr<G: DirectedGraph>(
+    _graph: &G,
+    data: &[u8],
+) -> Result<Location, DecodeError> {
+    // Step – 1 Decode physical data and check its validity
+    let location = deserialize_binary_openlr(data)?;
+
+    Err(DecodeError::LocationTypeNotSupported(
+        location.location_type(),
+    ))
+}

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -37,6 +37,12 @@ pub struct CandidateLine<EdgeId> {
     pub distance_to_projection: Option<Length>,
 }
 
+impl<EdgeId> CandidateLine<EdgeId> {
+    pub const fn is_projected(&self) -> bool {
+        self.distance_to_projection.is_some()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CandidateLinePair<EdgeId> {
     pub line_lrp1: CandidateLine<EdgeId>,

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -1,0 +1,57 @@
+use tracing::debug;
+
+use crate::{DecoderConfig, DirectedGraph, Length, Point};
+
+/// List of candidate nodes for a Location Reference Point.
+/// Nodes are sorted based on their distance to the point (closest to farthest).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CandidateNodes<VertexId> {
+    pub lrp: Point,
+    pub nodes: Vec<CandidateNode<VertexId>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CandidateNode<VertexId> {
+    pub vertex: VertexId,
+    pub distance_to_lrp: Length,
+}
+
+/// Each location reference point contains coordinates specifying a node in the encoder map. The
+/// decoder should try to find so called candidate nodes in the decoder map whereby the coordinates
+/// of the candidate nodes are close to the coordinates of the location reference point coordinates.
+/// The straight line distance should be used to identify close-by nodes. Nodes in the decoder map
+/// which are far away from the coordinates of the location reference point should not be considered
+/// as candidate nodes in the further processing. It might happen that several candidate nodes for
+/// one location reference point exist.
+///
+/// If no candidate node has been determined for a location reference point the decoder should try
+/// to determine a candidate line directly. The LRP coordinate can be projected onto lines which are
+/// not far away from that coordinate.
+pub fn find_candidate_nodes<'a, G, I>(
+    config: &DecoderConfig,
+    graph: &G,
+    points: I,
+) -> impl Iterator<Item = CandidateNodes<G::VertexId>>
+where
+    G: DirectedGraph,
+    I: IntoIterator<Item = &'a Point>,
+{
+    let DecoderConfig {
+        max_node_distance, ..
+    } = config;
+
+    points.into_iter().map(move |&lrp| {
+        debug!("Finding candidate nodes for {lrp:?} at max {max_node_distance}");
+
+        let nodes: Vec<_> = graph
+            .nearest_vertices_within_distance(lrp.coordinate, *max_node_distance)
+            .map(|(vertex, distance_to_lrp)| CandidateNode {
+                vertex,
+                distance_to_lrp,
+            })
+            .collect();
+
+        debug_assert!(nodes.is_sorted_by_key(|n| n.distance_to_lrp));
+        CandidateNodes { lrp, nodes }
+    })
+}

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -21,13 +21,13 @@ pub struct CandidateNode<VertexId> {
 
 /// List of candidate lines for a Location Reference Point.
 /// Lines are sorted based on their rating (descending - higher rating is better).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CandidateLines<EdgeId> {
     pub lrp: Point,
     pub lines: Vec<CandidateLine<EdgeId>>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CandidateLine<EdgeId> {
     pub lrp: Point,
     pub edge: EdgeId,
@@ -35,6 +35,18 @@ pub struct CandidateLine<EdgeId> {
     /// If this line is the result of a projection of the LRP into it, this represents the distance
     /// from the beginning of the line (start vertex) to the point where the LRP was projected.
     pub distance_to_projection: Option<Length>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CandidateLinePair<EdgeId> {
+    pub line_lrp1: CandidateLine<EdgeId>,
+    pub line_lrp2: CandidateLine<EdgeId>,
+}
+
+impl<EdgeId> CandidateLinePair<EdgeId> {
+    pub fn rating(&self) -> RatingScore {
+        self.line_lrp1.rating * self.line_lrp2.rating
+    }
 }
 
 /// Candidate line that is yet to be rated.

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -27,6 +27,12 @@ pub struct CandidateLines<EdgeId> {
     pub lines: Vec<CandidateLine<EdgeId>>,
 }
 
+impl<EdgeId: Copy> CandidateLines<EdgeId> {
+    pub fn best_candidate(&self) -> Option<CandidateLine<EdgeId>> {
+        self.lines.first().copied()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CandidateLine<EdgeId> {
     pub lrp: Point,

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -102,7 +102,8 @@ pub fn find_candidate_nodes<'a, G, I>(
 ) -> impl ExactSizeIterator<Item = CandidateNodes<G::VertexId>>
 where
     G: DirectedGraph,
-    I: ExactSizeIterator<Item = &'a Point>,
+    I: IntoIterator,
+    I::IntoIter: ExactSizeIterator<Item = &'a Point>,
 {
     let DecoderConfig {
         max_node_distance, ..
@@ -147,8 +148,10 @@ pub fn find_candidate_lines<G: DirectedGraph, I>(
     candidate_nodes: I,
 ) -> Result<Vec<CandidateLines<G::EdgeId>>, DecodeError>
 where
-    I: ExactSizeIterator<Item = CandidateNodes<G::VertexId>>,
+    I: IntoIterator,
+    I::IntoIter: ExactSizeIterator<Item = CandidateNodes<G::VertexId>>,
 {
+    let candidate_nodes = candidate_nodes.into_iter();
     let mut candidate_lines = Vec::with_capacity(candidate_nodes.len());
 
     for lrp_nodes in candidate_nodes {

--- a/src/decoder/line.rs
+++ b/src/decoder/line.rs
@@ -10,7 +10,7 @@ pub fn decode_line<G: DirectedGraph>(
     config: &DecoderConfig,
     graph: &G,
     line: Line,
-) -> Result<LineLocation, DecodeError> {
+) -> Result<LineLocation<G::EdgeId>, DecodeError> {
     info!("Decoding {line:?} with {config:?}");
 
     // Step – 2 For each location reference point find candidate nodes
@@ -27,9 +27,9 @@ pub fn decode_line<G: DirectedGraph>(
     let routes = resolve_routes(config, graph, &lines)?;
     debug_assert_eq!(routes.len(), line.points.len() - 1);
 
-    // Step – 7 Concatenate shortest-path(s) to form the location
-    // and trim path according to the offsets
+    // Step – 7 Concatenate and trim path according to the offsets
     let offsets = routes.calculate_offsets(graph, line.offsets);
+    let (pos_offset, neg_offset) = offsets.unwrap_or_default();
 
-    todo!()
+    routes.into_line_location(graph, pos_offset, neg_offset)
 }

--- a/src/decoder/line.rs
+++ b/src/decoder/line.rs
@@ -1,0 +1,35 @@
+use tracing::info;
+
+use crate::model::LineLocation;
+use crate::{
+    DecodeError, DecoderConfig, DirectedGraph, Line, find_candidate_lines, find_candidate_nodes,
+    resolve_routes,
+};
+
+pub fn decode_line<G: DirectedGraph>(
+    config: &DecoderConfig,
+    graph: &G,
+    line: Line,
+) -> Result<LineLocation, DecodeError> {
+    info!("Decoding {line:?} with {config:?}");
+
+    // Step – 2 For each location reference point find candidate nodes
+    let nodes = find_candidate_nodes(config, graph, &line.points);
+    debug_assert_eq!(nodes.len(), line.points.len());
+
+    // Step – 3 For each location reference point find candidate lines
+    // Step – 4 Rate candidate lines for each location reference point
+    let lines = find_candidate_lines(config, graph, nodes)?;
+    debug_assert_eq!(lines.len(), line.points.len());
+
+    // Step – 5 Determine shortest-path(s) between all subsequent location reference points
+    // Step – 6 Check validity of the calculated shortest-path(s)
+    let routes = resolve_routes(config, graph, &lines)?;
+    debug_assert_eq!(routes.len(), line.points.len() - 1);
+
+    // Step – 7 Concatenate shortest-path(s) to form the location
+    // and trim path according to the offsets
+    let offsets = routes.calculate_offsets(graph, line.offsets);
+
+    todo!()
+}

--- a/src/decoder/resolver.rs
+++ b/src/decoder/resolver.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Shortest path from the LRP to the next one.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Route<EdgeId> {
     pub lrp: Point,
     pub length: Length,

--- a/src/decoder/resolver.rs
+++ b/src/decoder/resolver.rs
@@ -1,0 +1,55 @@
+use base64::DecodeError;
+
+use crate::{CandidateLines, DecoderConfig, DirectedGraph, Length, Point};
+
+/// Shortest path from the LRP to the next one.
+#[derive(Debug, Default)]
+pub struct Route<EdgeId> {
+    pub lrp: Point,
+    pub length: Length,
+    pub edges: Vec<EdgeId>,
+}
+
+/// The decoder needs to compute a shortest-path between each pair of subsequent location reference
+/// points. For each pair of location reference points suitable candidate lines must be chosen. The
+/// candidate line of the first LRPs of this pair acts as start of the shortest-path calculation.
+/// The candidate line of the second location reference point of this pair is the end of the
+/// shortest-path calculation. If the chosen lines are equal no shortest-path calculation needs to
+/// be started.
+///
+/// The shortest path algorithm should take the part of the network into account which contains all
+/// lines having a functional road class lower than or equal to the lowest functional road class of
+/// the first location reference point of the pair. This value might be altered if the decoder
+/// anticipates having different functional road class values than the encoder map.
+///
+/// Additionally the shortest-path algorithm should fulfill the following constraints:
+/// - All lengths of the lines should be measured in meters and should also be converted to
+///   integer values, float values need to be rounded correctly.
+/// - The search is node based and will start at the start node of the first line and will end at
+///   the end node of the last line.
+/// - The algorithm shall return an ordered list of lines representing the calculated shortest-path.
+///
+/// If no shortest-path can be calculated for two subsequent location reference points, the decoder
+/// might try a different pair of candidate lines or finally fail and report an error. If a
+/// different pair of candidate lines is tried it might happen that the start line needs to be
+/// changed. In such a case this also affects the end line of the previous shortest-path and this
+/// path also needs to be re-calculated and checked again. The number of retries of shortest-path
+/// calculations should be limited in order to guarantee a fast decoding process.
+pub fn resolve_routes<G: DirectedGraph>(
+    config: &DecoderConfig,
+    graph: &G,
+    candidate_lines: &[CandidateLines<G::EdgeId>],
+) -> Result<Vec<Route<G::EdgeId>>, DecodeError> {
+    let mut routes = Vec::with_capacity(candidate_lines.len() - 1);
+
+    // TODO: check for single route
+
+    for candidates_pair in candidate_lines.windows(2) {
+        let [candidates_lrp1, candidates_lrp2] = [&candidates_pair[0], &candidates_pair[1]];
+
+        // TODO: resolve candidate pairs order
+        // TODO: for each pair calculate shortest path
+    }
+
+    Ok(routes)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ pub enum DecodeError {
     InvalidData(DeserializeError),
     #[error("Cannot find candidates for {0:?}")]
     CandidatesNotFound(Point),
+    #[error("Cannot find route between LRPs {0:?}")]
+    RouteNotFound((Point, Point)),
 }
 
 impl From<DeserializeError> for DecodeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,8 @@ pub enum DecodeError {
     CandidatesNotFound(Point),
     #[error("Cannot find route between LRPs {0:?}")]
     RouteNotFound((Point, Point)),
+    #[error("Cannot connect route to shortest path {0:?}")]
+    AlternativeRouteNotFound((Point, Point)),
 }
 
 impl From<DeserializeError> for DecodeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 
 use thiserror::Error;
 
-use crate::LocationType;
+use crate::{LocationType, Point};
 
 #[derive(Error, Debug, PartialEq, Clone, Copy)]
 pub enum DeserializeError {
@@ -48,6 +48,8 @@ pub enum DecodeError {
     LocationTypeNotSupported(LocationType),
     #[error("Cannot deserialize: {0}")]
     InvalidData(DeserializeError),
+    #[error("Cannot find candidates for {0:?}")]
+    CandidatesNotFound(Point),
 }
 
 impl From<DeserializeError> for DecodeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use std::io::ErrorKind;
 
 use thiserror::Error;
 
+use crate::LocationType;
+
 #[derive(Error, Debug, PartialEq, Clone, Copy)]
 pub enum DeserializeError {
     #[error("OpenLR invalid Base 64")]
@@ -38,6 +40,20 @@ pub enum SerializeError {
     InvalidRectangle,
     #[error("OpenLR Grid size must have number of columns and rows > 1")]
     InvalidGridSize,
+}
+
+#[derive(Error, Debug, PartialEq, Clone, Copy)]
+pub enum DecodeError {
+    #[error("Decoding {0:?} is not supported")]
+    LocationTypeNotSupported(LocationType),
+    #[error("Cannot deserialize: {0}")]
+    InvalidData(DeserializeError),
+}
+
+impl From<DeserializeError> for DecodeError {
+    fn from(error: DeserializeError) -> Self {
+        Self::InvalidData(error)
+    }
 }
 
 impl From<base64::DecodeError> for DeserializeError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 
 use thiserror::Error;
 
-use crate::{LocationType, Point};
+use crate::{Length, LocationType, Point};
 
 #[derive(Error, Debug, PartialEq, Clone, Copy)]
 pub enum DeserializeError {
@@ -54,6 +54,8 @@ pub enum DecodeError {
     RouteNotFound((Point, Point)),
     #[error("Cannot connect route to shortest path {0:?}")]
     AlternativeRouteNotFound((Point, Point)),
+    #[error("Invalid offsets {0:?}")]
+    InvalidOffsets((Length, Length)),
 }
 
 impl From<DeserializeError> for DecodeError {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,93 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use crate::{Bearing, Coordinate, Fow, Frc, Length};
+
+/// Directed graph.
+/// Exposes the behavior of a Geospatial Index and a Road Network Graph.
+/// Should be implemented by the graph the represents the map the decoder is supposed to run on.
+pub trait DirectedGraph {
+    /// Uniquely identify a vertex that belongs to the graph.
+    type VertexId: Debug + Copy + Ord + Hash;
+    /// Uniquely identify a directed edge that belongs to the graph.
+    type EdgeId: Debug + Copy + PartialEq;
+
+    /// Gets the start vertex of the directed edge.
+    /// Returns None if the edge doesn't belong to the graph.
+    fn get_edge_start_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId>;
+
+    /// Gets the end vertex of the directed edge.
+    /// Returns None if the edge doesn't belong to the graph.
+    fn get_edge_end_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId>;
+
+    /// Gets the total length of the directed edge.
+    /// Returns None if the edge doesn't belong to the graph.
+    fn get_edge_length(&self, edge: Self::EdgeId) -> Option<Length>;
+
+    /// Gets the Functional Road Class of the directed edge.
+    /// Returns None if the edge doesn't belong to the graph.
+    fn get_edge_frc(&self, edge: Self::EdgeId) -> Option<Frc>;
+
+    /// Gets the Form of Way of the directed edge.
+    /// Returns None if the edge doesn't belong to the graph.
+    fn get_edge_fow(&self, edge: Self::EdgeId) -> Option<Fow>;
+
+    /// Gets an iterator over all the coordinates of the directed edge.
+    /// The coordinates will be sorted from the first vertex to the last vertex.
+    /// Returns an empty iterator if the edge doesn't belong to the graph.
+    fn get_edge_coordinates(&self, edge: Self::EdgeId) -> impl Iterator<Item = Coordinate>;
+
+    /// Gets an iterator over all the outgoing edges from the given vertex.
+    /// For each edge returns the edge ID and the edge end vertex.
+    /// Returns an empty iterator if the vertex doesn't belong to the graph.
+    fn vertex_exiting_edges(
+        &self,
+        vertex: Self::VertexId,
+    ) -> impl Iterator<Item = (Self::EdgeId, Self::VertexId)>;
+
+    /// Gets an iterator over all the incoming edges to the given vertex.
+    /// For each edge returns the edge ID and the edge start vertex.
+    /// Returns an empty iterator if the vertex doesn't belong to the graph.
+    fn vertex_entering_edges(
+        &self,
+        vertex: Self::VertexId,
+    ) -> impl Iterator<Item = (Self::EdgeId, Self::VertexId)>;
+
+    /// Gets an iterator over all the vertices that are within a max distance from the coordinate.
+    /// For each vertex also returns the distance from the coordinate.
+    /// Returns an empty iterator if no vertex could be found within distance.
+    fn nearest_vertices_within_distance(
+        &self,
+        coordinate: Coordinate,
+        max_distance: Length,
+    ) -> impl Iterator<Item = (Self::VertexId, Length)>;
+
+    /// Gets an iterator over all the edges that are within a max distance from the coordinate.
+    /// For each edges also returns the distance from the coordinate.
+    /// Returns an empty iterator if no vertex could be found within distance.
+    fn nearest_edges_within_distance(
+        &self,
+        coordinate: Coordinate,
+        max_distance: Length,
+    ) -> impl Iterator<Item = (Self::EdgeId, Length)>;
+
+    /// Gets the distance of the projected coordinate to the start vertex of the edge when following
+    /// the edge coordinates.
+    /// Returns None if the edge doesn't belong to the graph or if the coordinate cannot be projected.
+    fn get_distance_from_start_vertex(
+        &self,
+        edge: Self::EdgeId,
+        coordinate: Coordinate,
+    ) -> Option<Length>;
+
+    /// Gets the bearing of a subsection A-B of the edge that goes from the coordinate (A) at the
+    /// given distance from the start vertex, and the coordinate (B) that is at the given distance
+    /// from A. The segment length can be negative.
+    /// Returns None if the edge doesn't belong to the graph or if the segment cannot be constructed.
+    fn get_edge_bearing_between(
+        &self,
+        edge: Self::EdgeId,
+        distance_from_start: Length,
+        segment_length: Length,
+    ) -> Option<Bearing>;
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -55,6 +55,7 @@ pub trait DirectedGraph {
 
     /// Gets an iterator over all the vertices that are within a max distance from the coordinate.
     /// For each vertex also returns the distance from the coordinate.
+    /// Vertices must be returned sorted by their distance to the coordinate.
     /// Returns an empty iterator if no vertex could be found within distance.
     fn nearest_vertices_within_distance(
         &self,
@@ -64,6 +65,7 @@ pub trait DirectedGraph {
 
     /// Gets an iterator over all the edges that are within a max distance from the coordinate.
     /// For each edges also returns the distance from the coordinate.
+    /// Edges must be returned sorted by their distance to the coordinate.
     /// Returns an empty iterator if no vertex could be found within distance.
     fn nearest_edges_within_distance(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@ pub use binary::{
     deserialize_base64_openlr, deserialize_binary_openlr, serialize_base64_openlr,
     serialize_binary_openlr,
 };
-pub use decoder::candidates::{CandidateNode, CandidateNodes, find_candidate_nodes};
+pub use decoder::candidates::{
+    CandidateLine, CandidateLines, CandidateNode, CandidateNodes, find_candidate_lines,
+    find_candidate_nodes,
+};
 pub use decoder::{DecoderConfig, decode_base64_openlr, decode_binary_openlr};
 pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ pub use binary::{
     deserialize_base64_openlr, deserialize_binary_openlr, serialize_base64_openlr,
     serialize_binary_openlr,
 };
-pub use decoder::{decode_base64_openlr, decode_binary_openlr};
+pub use decoder::candidates::{CandidateNode, CandidateNodes, find_candidate_nodes};
+pub use decoder::{DecoderConfig, decode_base64_openlr, decode_binary_openlr};
 pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;
 pub use model::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod decoder;
 mod error;
 mod graph;
 mod model;
+mod routing;
 
 pub use binary::{
     deserialize_base64_openlr, deserialize_binary_openlr, serialize_base64_openlr,
@@ -23,3 +24,4 @@ pub use model::{
     LineAttributes, Location, LocationReference, LocationType, Offset, Orientation, PathAttributes,
     Poi, Point, PointAlongLine, Polygon, Rating, RatingScore, Rectangle, SideOfRoad,
 };
+pub use routing::{ShortestPath, ShortestPathConfig, shortest_path};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,15 @@ pub use decoder::candidates::{
     CandidateLine, CandidateLinePair, CandidateLines, CandidateNode, CandidateNodes,
     find_candidate_lines, find_candidate_nodes,
 };
-pub use decoder::resolver::{Route, resolve_routes};
+pub use decoder::line::decode_line;
+pub use decoder::resolver::{Route, Routes, resolve_routes};
 pub use decoder::{DecoderConfig, decode_base64_openlr, decode_binary_openlr};
 pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;
 pub use model::{
     Bearing, Circle, ClosedLine, Coordinate, Fow, Frc, Grid, GridSize, Length, Line,
-    LineAttributes, Location, LocationReference, LocationType, Offset, Orientation, PathAttributes,
-    Poi, Point, PointAlongLine, Polygon, Rating, RatingScore, Rectangle, SideOfRoad,
+    LineAttributes, Location, LocationReference, LocationType, Offset, Offsets, Orientation,
+    PathAttributes, Poi, Point, PointAlongLine, Polygon, Rating, RatingScore, Rectangle,
+    SideOfRoad,
 };
 pub use routing::{ShortestPath, ShortestPathConfig, shortest_path};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod binary;
+mod decoder;
 mod error;
 mod graph;
 mod model;
@@ -9,10 +10,11 @@ pub use binary::{
     deserialize_base64_openlr, deserialize_binary_openlr, serialize_base64_openlr,
     serialize_binary_openlr,
 };
-pub use error::{DeserializeError, SerializeError};
+pub use decoder::{decode_base64_openlr, decode_binary_openlr};
+pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;
 pub use model::{
     Bearing, Circle, ClosedLine, Coordinate, Fow, Frc, Grid, GridSize, Length, Line,
-    LineAttributes, LocationReference, LocationType, Offset, Orientation, PathAttributes, Poi,
-    Point, PointAlongLine, Polygon, Rectangle, SideOfRoad,
+    LineAttributes, Location, LocationReference, LocationType, Offset, Orientation, PathAttributes,
+    Poi, Point, PointAlongLine, Polygon, Rectangle, SideOfRoad,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use decoder::candidates::{
     CandidateLine, CandidateLines, CandidateNode, CandidateNodes, find_candidate_lines,
     find_candidate_nodes,
 };
+pub use decoder::resolver::{Route, resolve_routes};
 pub use decoder::{DecoderConfig, decode_base64_openlr, decode_binary_openlr};
 pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ pub use error::{DecodeError, DeserializeError, SerializeError};
 pub use graph::DirectedGraph;
 pub use model::{
     Bearing, Circle, ClosedLine, Coordinate, Fow, Frc, Grid, GridSize, Length, Line,
-    LineAttributes, Location, LocationReference, LocationType, Offset, Offsets, Orientation,
-    PathAttributes, Poi, Point, PointAlongLine, Polygon, Rating, RatingScore, Rectangle,
-    SideOfRoad,
+    LineAttributes, LineLocation, Location, LocationReference, LocationType, Offset, Offsets,
+    Orientation, PathAttributes, Poi, Point, PointAlongLine, Polygon, Rating, RatingScore,
+    Rectangle, SideOfRoad,
 };
 pub use routing::{ShortestPath, ShortestPathConfig, shortest_path};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod binary;
 mod error;
+mod graph;
 mod model;
 
 pub use binary::{
@@ -9,6 +10,7 @@ pub use binary::{
     serialize_binary_openlr,
 };
 pub use error::{DeserializeError, SerializeError};
+pub use graph::DirectedGraph;
 pub use model::{
     Bearing, Circle, ClosedLine, Coordinate, Fow, Frc, Grid, GridSize, Length, Line,
     LineAttributes, LocationReference, LocationType, Offset, Orientation, PathAttributes, Poi,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,5 @@ pub use graph::DirectedGraph;
 pub use model::{
     Bearing, Circle, ClosedLine, Coordinate, Fow, Frc, Grid, GridSize, Length, Line,
     LineAttributes, Location, LocationReference, LocationType, Offset, Orientation, PathAttributes,
-    Poi, Point, PointAlongLine, Polygon, Rectangle, SideOfRoad,
+    Poi, Point, PointAlongLine, Polygon, Rating, RatingScore, Rectangle, SideOfRoad,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pub use binary::{
     serialize_binary_openlr,
 };
 pub use decoder::candidates::{
-    CandidateLine, CandidateLines, CandidateNode, CandidateNodes, find_candidate_lines,
-    find_candidate_nodes,
+    CandidateLine, CandidateLinePair, CandidateLines, CandidateNode, CandidateNodes,
+    find_candidate_lines, find_candidate_nodes,
 };
 pub use decoder::resolver::{Route, resolve_routes};
 pub use decoder::{DecoderConfig, decode_base64_openlr, decode_binary_openlr};

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 use approx::abs_diff_eq;
@@ -339,6 +340,12 @@ impl SubAssign for Length {
     }
 }
 
+impl Sum for Length {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |a, b| a + b)
+    }
+}
+
 /// The bearing describes the angle between the true North and the road.
 /// The physical data format defines the bearing field as an integer value between 0
 /// and 360 whereby “0” is included and “360” is excluded from that range.
@@ -470,7 +477,7 @@ impl Point {
 /// bounding to the nodes in a network. The logical format defines two offsets,
 /// one at the start of the location and one at the end of the location.
 /// Both offsets operate along the lines of the location and are measured in meters.
-// The offset values are optional and a missing offset value means an offset of 0 meters.
+/// The offset values are optional and a missing offset value means an offset of 0 meters.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Offset(f64);
 
@@ -511,6 +518,16 @@ impl Offsets {
             pos: offset,
             neg: Offset::default(),
         }
+    }
+
+    pub fn distance_from_start(&self, length: Length) -> Length {
+        let length = (self.pos.range() * length.meters()).round();
+        Length::from_meters(length)
+    }
+
+    pub fn distance_to_end(&self, length: Length) -> Length {
+        let length = (self.neg.range() * length.meters()).round();
+        Length::from_meters(length)
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -283,18 +283,12 @@ impl Default for Orientation {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Length(OrderedFloat<f64>);
 
 impl fmt::Display for Length {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:.1}m", self.meters())
-    }
-}
-
-impl fmt::Debug for Length {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Length({:.1})", self.0)
     }
 }
 
@@ -703,8 +697,12 @@ impl LocationReference {
 /// and is also the result of the decoding process.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Location {
-    Line,
+    Line(LineLocation),
 }
+
+/// Location (in a map) that represents a Line Location Reference.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LineLocation;
 
 #[cfg(test)]
 mod tests {

--- a/src/model.rs
+++ b/src/model.rs
@@ -305,6 +305,10 @@ impl Length {
         self.0.0
     }
 
+    pub fn is_zero(&self) -> bool {
+        *self == Self::ZERO
+    }
+
     pub fn round(self) -> Self {
         Self(self.0.round().into())
     }
@@ -343,6 +347,20 @@ impl SubAssign for Length {
 impl Sum for Length {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |a, b| a + b)
+    }
+}
+
+impl Mul<f64> for Length {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl Mul<Length> for f64 {
+    type Output = Length;
+    fn mul(self, rhs: Length) -> Self::Output {
+        Length(OrderedFloat(self) * rhs.0)
     }
 }
 
@@ -713,13 +731,20 @@ impl LocationReference {
 /// Defines a location (in a map) which can be encoded using the OpenLR encoder
 /// and is also the result of the decoding process.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Location {
-    Line(LineLocation),
+pub enum Location<EdgeId> {
+    Line(LineLocation<EdgeId>),
 }
 
 /// Location (in a map) that represents a Line Location Reference.
 #[derive(Debug, Clone, PartialEq)]
-pub struct LineLocation;
+pub struct LineLocation<EdgeId> {
+    /// Complete list of edges that form the line.
+    pub edges: Vec<EdgeId>,
+    /// Distance from the start of the first edge to the beginning of the location.
+    pub pos_offset: Length,
+    /// Distance from the end of the last edge to the end of the location.
+    pub neg_offset: Length,
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/model.rs
+++ b/src/model.rs
@@ -699,6 +699,13 @@ impl LocationReference {
     }
 }
 
+/// Defines a location (in a map) which can be encoded using the OpenLR encoder
+/// and is also the result of the decoding process.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Location {
+    Line,
+}
+
 #[cfg(test)]
 mod tests {
     use strum::IntoEnumIterator;

--- a/src/model.rs
+++ b/src/model.rs
@@ -193,6 +193,14 @@ impl Default for Fow {
 }
 
 impl Fow {
+    pub const fn value(&self) -> i8 {
+        self.into_byte() as i8
+    }
+
+    pub fn from_value(value: i8) -> Option<Self> {
+        Self::try_from_byte(value.try_into().ok()?).ok()
+    }
+
     pub const fn rating(&self, other: &Self) -> Rating {
         use Fow::*;
         match (self, other) {
@@ -694,6 +702,7 @@ impl LocationReference {
 #[cfg(test)]
 mod tests {
     use strum::IntoEnumIterator;
+    use test_log::test;
 
     use super::*;
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,4 +1,8 @@
-//! https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::fmt::Debug;
+
+use tracing::debug;
 
 use crate::{DirectedGraph, Frc, Length};
 
@@ -23,11 +27,102 @@ pub struct ShortestPath<EdgeId> {
     pub edges: Vec<EdgeId>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HeapElement<VertexId> {
+    /// Current shortest distance from origin to this vertex.
+    distance: Length,
+    vertex: VertexId,
+}
+
+// The priority queue depends on the implementation of the Ord trait.
+// By default std::BinaryHeap is a max heap.
+// Explicitly implement the trait so the queue becomes a min heap.
+impl<VertexId: Ord> Ord for HeapElement<VertexId> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .distance
+            .cmp(&self.distance)
+            // breaking ties in a deterministic way
+            .then_with(|| other.vertex.cmp(&self.vertex))
+    }
+}
+
+impl<VertexId: Ord> PartialOrd for HeapElement<VertexId> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub fn shortest_path<G: DirectedGraph>(
     config: &ShortestPathConfig,
     graph: &G,
     origin: G::VertexId,
     destination: G::VertexId,
 ) -> Option<ShortestPath<G::EdgeId>> {
-    todo!()
+    debug!("Computing shortest path {origin:?} -> {destination:?} with {config:?}");
+
+    // (current) shortest distance from origin to this vertex
+    let mut shortest_distances = HashMap::from([(origin, Length::ZERO)]);
+
+    // previous vertex (value) on the current best known path from origin to this vertex (key)
+    let mut prev_vertex: HashMap<G::VertexId, (G::EdgeId, G::VertexId)> = HashMap::new();
+
+    // priority queue of discovered nodes that may need to be visited
+    let mut frontier = BinaryHeap::from([HeapElement {
+        vertex: origin,
+        distance: Length::ZERO,
+    }]);
+
+    while let Some(element) = frontier.pop() {
+        if element.vertex == destination {
+            // Unpacking: the shortest path from destination back to origin
+            let mut edges = vec![];
+            let mut next = destination;
+            while let Some(&(edge, previous)) = prev_vertex.get(&next) {
+                next = previous;
+                edges.push(edge);
+            }
+            edges.reverse();
+
+            return Some(ShortestPath {
+                length: element.distance,
+                edges,
+            });
+        }
+
+        // check if we already know a cheaper way to get to the end of this path from the origin
+        let shortest_distance = *shortest_distances
+            .get(&element.vertex)
+            .unwrap_or(&Length::MAX);
+        if element.distance > shortest_distance {
+            continue;
+        }
+
+        for (edge, vertex_to) in graph.vertex_exiting_edges(element.vertex) {
+            let distance = element.distance + graph.get_edge_length(edge)?;
+            if distance > config.max_length {
+                continue;
+            }
+
+            if graph.get_edge_frc(edge)? > config.lowest_frc {
+                continue;
+            }
+
+            let shortest_distance = *shortest_distances.get(&vertex_to).unwrap_or(&Length::MAX);
+            // check if we can follow the current path to reach the neighbor in a cheaper way
+            if distance < shortest_distance {
+                let neighbor = HeapElement {
+                    vertex: vertex_to,
+                    distance,
+                };
+
+                // Relax: we have now found a better way that we are going to explore
+                shortest_distances.insert(neighbor.vertex, neighbor.distance);
+                prev_vertex.insert(neighbor.vertex, (edge, element.vertex));
+                frontier.push(neighbor);
+            }
+        }
+    }
+
+    None
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,33 @@
+//! https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+
+use crate::{DirectedGraph, Frc, Length};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShortestPathConfig {
+    pub lowest_frc: Frc,
+    pub max_length: Length,
+}
+
+impl Default for ShortestPathConfig {
+    fn default() -> Self {
+        Self {
+            lowest_frc: Frc::Frc7,
+            max_length: Length::MAX,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ShortestPath<EdgeId> {
+    pub length: Length,
+    pub edges: Vec<EdgeId>,
+}
+
+pub fn shortest_path<G: DirectedGraph>(
+    config: &ShortestPathConfig,
+    graph: &G,
+    origin: G::VertexId,
+    destination: G::VertexId,
+) -> Option<ShortestPath<G::EdgeId>> {
+    todo!()
+}

--- a/tests/binary_serialization.rs
+++ b/tests/binary_serialization.rs
@@ -1,4 +1,5 @@
 use openlr::{LocationType, deserialize_base64_openlr, serialize_base64_openlr};
+use test_log::test;
 
 #[test]
 fn openlr_binary_deserialization() {

--- a/tests/data/graph.geojson
+++ b/tests/data/graph.geojson
@@ -1,0 +1,6815 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.454214,
+          52.5157088
+        ]
+      },
+      "id": "node-1"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 2
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.457386,
+          52.5153814
+        ]
+      },
+      "id": "node-2"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 3
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4589756,
+          52.515216
+        ]
+      },
+      "id": "node-3"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 4
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4647406,
+          52.5146335
+        ]
+      },
+      "id": "node-4"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 5
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4645716,
+          52.5142805
+        ]
+      },
+      "id": "node-5"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 6
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.463926,
+          52.5130035
+        ]
+      },
+      "id": "node-6"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 7
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4633349,
+          52.5147774
+        ]
+      },
+      "id": "node-7"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 8
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4630931,
+          52.5144057
+        ]
+      },
+      "id": "node-8"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 9
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4622714,
+          52.5131916
+        ]
+      },
+      "id": "node-9"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 10
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4536225,
+          52.5184558
+        ]
+      },
+      "id": "node-10"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 11
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4571122,
+          52.5177995
+        ]
+      },
+      "id": "node-11"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 12
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4615934,
+          52.5180374
+        ]
+      },
+      "id": "node-12"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 13
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4655844,
+          52.5173118
+        ]
+      },
+      "id": "node-13"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 14
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4587724,
+          52.520537
+        ]
+      },
+      "id": "node-14"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 15
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4580678,
+          52.5195445
+        ]
+      },
+      "id": "node-15"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 16
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4658638,
+          52.5179215
+        ]
+      },
+      "id": "node-16"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 17
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4651667,
+          52.5163591
+        ]
+      },
+      "id": "node-17"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 18
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.464386,
+          52.5148252
+        ]
+      },
+      "id": "node-18"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 19
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4637853,
+          52.5166159
+        ]
+      },
+      "id": "node-19"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 20
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4628442,
+          52.5149807
+        ]
+      },
+      "id": "node-20"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 21
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4581169,
+          52.5194882
+        ]
+      },
+      "id": "node-21"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 22
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4599884,
+          52.5191386
+        ]
+      },
+      "id": "node-22"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 23
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4619511,
+          52.5187508
+        ]
+      },
+      "id": "node-23"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 24
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4671734,
+          52.5177627
+        ]
+      },
+      "id": "node-24"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 25
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4672571,
+          52.5179261
+        ]
+      },
+      "id": "node-25"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 26
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4660337,
+          52.5182804
+        ]
+      },
+      "id": "node-26"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 27
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4675,
+          52.514512
+        ]
+      },
+      "id": "node-27"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 28
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.467463,
+          52.5143633
+        ]
+      },
+      "id": "node-28"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 29
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4694532,
+          52.5197829
+        ]
+      },
+      "id": "node-29"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 30
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4699091,
+          52.5198212
+        ]
+      },
+      "id": "node-30"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 31
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4593616,
+          52.5125053
+        ]
+      },
+      "id": "node-31"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 32
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4610713,
+          52.5145974
+        ]
+      },
+      "id": "node-32"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 33
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4611548,
+          52.5147052
+        ]
+      },
+      "id": "node-33"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 34
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4601262,
+          52.5151013
+        ]
+      },
+      "id": "node-34"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 35
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4623778,
+          52.5148788
+        ]
+      },
+      "id": "node-35"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 36
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4601915,
+          52.5152482
+        ]
+      },
+      "id": "node-36"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 37
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4553269,
+          52.5157401
+        ]
+      },
+      "id": "node-37"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 38
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4636778,
+          52.5199086
+        ]
+      },
+      "id": "node-38"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 39
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.46384,
+          52.5199217
+        ]
+      },
+      "id": "node-39"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 40
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4655333,
+          52.5200577
+        ]
+      },
+      "id": "node-40"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 41
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4659039,
+          52.5180116
+        ]
+      },
+      "id": "node-41"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 42
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4659771,
+          52.5181688
+        ]
+      },
+      "id": "node-42"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 43
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4620337,
+          52.5189155
+        ]
+      },
+      "id": "node-43"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 44
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4638238,
+          52.5200205
+        ]
+      },
+      "id": "node-44"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 45
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4636855,
+          52.5196353
+        ]
+      },
+      "id": "node-45"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 46
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4632681,
+          52.5197096
+        ]
+      },
+      "id": "node-46"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 47
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4664359,
+          52.5191265
+        ]
+      },
+      "id": "node-47"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 48
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4691926,
+          52.5186312
+        ]
+      },
+      "id": "node-48"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 49
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4717725,
+          52.5171749
+        ]
+      },
+      "id": "node-49"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 50
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4689664,
+          52.5176316
+        ]
+      },
+      "id": "node-50"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 51
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4695196,
+          52.5200682
+        ]
+      },
+      "id": "node-51"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 52
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4689136,
+          52.5174726
+        ]
+      },
+      "id": "node-52"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 53
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4684334,
+          52.5167789
+        ]
+      },
+      "id": "node-53"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 54
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4578115,
+          52.5127857
+        ]
+      },
+      "id": "node-54"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 55
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4545609,
+          52.513858
+        ]
+      },
+      "id": "node-55"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 56
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4686563,
+          52.5167401
+        ]
+      },
+      "id": "node-56"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 57
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4726201,
+          52.5160233
+        ]
+      },
+      "id": "node-57"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 58
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4572516,
+          52.5149212
+        ]
+      },
+      "id": "node-58"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 59
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4590401,
+          52.5148416
+        ]
+      },
+      "id": "node-59"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 60
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.460514,
+          52.5159006
+        ]
+      },
+      "id": "node-60"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 61
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4602666,
+          52.5159453
+        ]
+      },
+      "id": "node-61"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 62
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4708386,
+          52.5141744
+        ]
+      },
+      "id": "node-62"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 63
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.468332,
+          52.514428
+        ]
+      },
+      "id": "node-63"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 64
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4670479,
+          52.5160273
+        ]
+      },
+      "id": "node-64"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 65
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4656691,
+          52.5146948
+        ]
+      },
+      "id": "node-65"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 66
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4634379,
+          52.5143199
+        ]
+      },
+      "id": "node-66"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 67
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4591042,
+          52.5174553
+        ]
+      },
+      "id": "node-67"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 68
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4611206,
+          52.5170944
+        ]
+      },
+      "id": "node-68"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 69
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4664717,
+          52.5161278
+        ]
+      },
+      "id": "node-69"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 70
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4681029,
+          52.5158439
+        ]
+      },
+      "id": "node-70"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 71
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4703464,
+          52.5154417
+        ]
+      },
+      "id": "node-71"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 72
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4599436,
+          52.51489
+        ]
+      },
+      "id": "node-72"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 73
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4600972,
+          52.5148327
+        ]
+      },
+      "id": "node-73"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 74
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4602568,
+          52.5147763
+        ]
+      },
+      "id": "node-74"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 75
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.459407,
+          52.5143601
+        ]
+      },
+      "id": "node-75"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 76
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.468463,
+          52.5125412
+        ]
+      },
+      "id": "node-76"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 77
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4696325,
+          52.5141418
+        ]
+      },
+      "id": "node-77"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 78
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4624949,
+          52.519861
+        ]
+      },
+      "id": "node-78"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 79
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4567043,
+          52.516356
+        ]
+      },
+      "id": "node-79"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 80
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4571604,
+          52.5163129
+        ]
+      },
+      "id": "node-80"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 81
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4578996,
+          52.5162418
+        ]
+      },
+      "id": "node-81"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 82
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4583666,
+          52.5161997
+        ]
+      },
+      "id": "node-82"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 83
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4559287,
+          52.5193482
+        ]
+      },
+      "id": "node-83"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 84
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4603798,
+          52.5156268
+        ]
+      },
+      "id": "node-84"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 85
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4617642,
+          52.5199904
+        ]
+      },
+      "id": "node-85"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 86
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4596856,
+          52.5185621
+        ]
+      },
+      "id": "node-86"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 87
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4614437,
+          52.5158342
+        ]
+      },
+      "id": "node-87"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 88
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4617042,
+          52.5160751
+        ]
+      },
+      "id": "node-88"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 89
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4613231,
+          52.5157223
+        ]
+      },
+      "id": "node-89"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 90
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4609064,
+          52.5151775
+        ]
+      },
+      "id": "node-90"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 91
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4609408,
+          52.5152926
+        ]
+      },
+      "id": "node-91"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 92
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4618955,
+          52.5162491
+        ]
+      },
+      "id": "node-92"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 93
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4619574,
+          52.5163044
+        ]
+      },
+      "id": "node-93"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 94
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4609759,
+          52.5154164
+        ]
+      },
+      "id": "node-94"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 95
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4630579,
+          52.5167465
+        ]
+      },
+      "id": "node-95"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 96
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4622184,
+          52.5158742
+        ]
+      },
+      "id": "node-96"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 97
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4664872,
+          52.5146131
+        ]
+      },
+      "id": "node-97"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 98
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4665181,
+          52.5147222
+        ]
+      },
+      "id": "node-98"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 99
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4665422,
+          52.5148305
+        ]
+      },
+      "id": "node-99"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 100
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4709624,
+          52.5183183
+        ]
+      },
+      "id": "node-100"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 101
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4643394,
+          52.5146736
+        ]
+      },
+      "id": "node-101"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 102
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4627936,
+          52.5148339
+        ]
+      },
+      "id": "node-102"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 103
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4619458,
+          52.5146163
+        ]
+      },
+      "id": "node-103"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 104
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4617983,
+          52.5143111
+        ]
+      },
+      "id": "node-104"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 105
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4551048,
+          52.5152531
+        ]
+      },
+      "id": "node-105"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 106
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4644002,
+          52.5143113
+        ]
+      },
+      "id": "node-106"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 107
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4642308,
+          52.5143447
+        ]
+      },
+      "id": "node-107"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 108
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4635899,
+          52.5144763
+        ]
+      },
+      "id": "node-108"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 109
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4578493,
+          52.5190142
+        ]
+      },
+      "id": "node-109"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 110
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4576677,
+          52.518717
+        ]
+      },
+      "id": "node-110"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 111
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4560582,
+          52.5167925
+        ]
+      },
+      "id": "node-111"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 112
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4654654,
+          52.5147163
+        ]
+      },
+      "id": "node-112"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 113
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.463911,
+          52.5148731
+        ]
+      },
+      "id": "node-113"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 114
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4667149,
+          52.5144364
+        ]
+      },
+      "id": "node-114"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 115
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4612277,
+          52.5151437
+        ]
+      },
+      "id": "node-115"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 116
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4661309,
+          52.5144947
+        ]
+      },
+      "id": "node-116"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 117
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4580688,
+          52.5189743
+        ]
+      },
+      "id": "node-117"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 118
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4579134,
+          52.5186781
+        ]
+      },
+      "id": "node-118"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 119
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4580594,
+          52.5186534
+        ]
+      },
+      "id": "node-119"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 120
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4587602,
+          52.5188493
+        ]
+      },
+      "id": "node-120"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 121
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4600694,
+          52.5159805
+        ]
+      },
+      "id": "node-121"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 122
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4590979,
+          52.5162475
+        ]
+      },
+      "id": "node-122"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 123
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4585643,
+          52.5162981
+        ]
+      },
+      "id": "node-123"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 124
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4569887,
+          52.5163301
+        ]
+      },
+      "id": "node-124"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 125
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4598686,
+          52.5170028
+        ]
+      },
+      "id": "node-125"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 126
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4659827,
+          52.5153731
+        ]
+      },
+      "id": "node-126"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 127
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4661547,
+          52.5153925
+        ]
+      },
+      "id": "node-127"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 128
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4658069,
+          52.5152145
+        ]
+      },
+      "id": "node-128"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 129
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4658863,
+          52.5152834
+        ]
+      },
+      "id": "node-129"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 130
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4656961,
+          52.5151315
+        ]
+      },
+      "id": "node-130"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 131
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4655257,
+          52.5149424
+        ]
+      },
+      "id": "node-131"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 132
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4654955,
+          52.5148269
+        ]
+      },
+      "id": "node-132"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 133
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4602779,
+          52.5184519
+        ]
+      },
+      "id": "node-133"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 134
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4587361,
+          52.516543
+        ]
+      },
+      "id": "node-134"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 135
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4656389,
+          52.5128301
+        ]
+      },
+      "id": "node-135"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 136
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4663561,
+          52.5161471
+        ]
+      },
+      "id": "node-136"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 137
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4669903,
+          52.5126895
+        ]
+      },
+      "id": "node-137"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 138
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4590704,
+          52.5144901
+        ]
+      },
+      "id": "node-138"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 139
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.458825,
+          52.5145838
+        ]
+      },
+      "id": "node-139"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 140
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4592303,
+          52.5144292
+        ]
+      },
+      "id": "node-140"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 141
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4719541,
+          52.5169302
+        ]
+      },
+      "id": "node-141"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 142
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4669131,
+          52.5201686
+        ]
+      },
+      "id": "node-142"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": 143
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.4664356,
+          52.5160603
+        ]
+      },
+      "id": "node-143"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 2,
+        "startId": 1,
+        "frc": 2,
+        "length": 217,
+        "id": 16218,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.454214,
+            52.5157088
+          ],
+          [
+            13.4543909,
+            52.5156905
+          ],
+          [
+            13.4547221,
+            52.5156587
+          ],
+          [
+            13.4554821,
+            52.5155823
+          ],
+          [
+            13.4559786,
+            52.5155295
+          ],
+          [
+            13.4568703,
+            52.5154347
+          ],
+          [
+            13.457386,
+            52.5153814
+          ]
+        ]
+      },
+      "id": "link-16218"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 3,
+        "startId": 2,
+        "frc": 2,
+        "length": 109,
+        "id": 16219,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.457386,
+            52.5153814
+          ],
+          [
+            13.4577545,
+            52.5153434
+          ],
+          [
+            13.4589756,
+            52.515216
+          ]
+        ]
+      },
+      "id": "link-16219"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 5,
+        "startId": 4,
+        "frc": 6,
+        "length": 40,
+        "id": 79715,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4647406,
+            52.5146335
+          ],
+          [
+            13.4647178,
+            52.5145858
+          ],
+          [
+            13.4645716,
+            52.5142805
+          ]
+        ]
+      },
+      "id": "link-79715"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 6,
+        "startId": 5,
+        "frc": 6,
+        "length": 148,
+        "id": 79716,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4645716,
+            52.5142805
+          ],
+          [
+            13.4643918,
+            52.513933
+          ],
+          [
+            13.463926,
+            52.5130035
+          ]
+        ]
+      },
+      "id": "link-79716"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 8,
+        "startId": 7,
+        "frc": 6,
+        "length": 44,
+        "id": 86727,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4633349,
+            52.5147774
+          ],
+          [
+            13.4630931,
+            52.5144057
+          ]
+        ]
+      },
+      "id": "link-86727"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 9,
+        "startId": 8,
+        "frc": 6,
+        "length": 146,
+        "id": 86728,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4630931,
+            52.5144057
+          ],
+          [
+            13.4622714,
+            52.5131916
+          ]
+        ]
+      },
+      "id": "link-86728"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 11,
+        "startId": 10,
+        "frc": 6,
+        "length": 247,
+        "id": 109776,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4536225,
+            52.5184558
+          ],
+          [
+            13.4543906,
+            52.5183122
+          ],
+          [
+            13.4571122,
+            52.5177995
+          ]
+        ]
+      },
+      "id": "link-109776"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 13,
+        "startId": 12,
+        "frc": 6,
+        "length": 281,
+        "id": 109777,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4615934,
+            52.5180374
+          ],
+          [
+            13.464541,
+            52.5175015
+          ],
+          [
+            13.4651701,
+            52.5173871
+          ],
+          [
+            13.4655844,
+            52.5173118
+          ]
+        ]
+      },
+      "id": "link-109777"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 15,
+        "startId": 14,
+        "frc": 6,
+        "length": 121,
+        "id": 109779,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4587724,
+            52.520537
+          ],
+          [
+            13.4581547,
+            52.5195891
+          ],
+          [
+            13.4580678,
+            52.5195445
+          ]
+        ]
+      },
+      "id": "link-109779"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 13,
+        "startId": 16,
+        "frc": 6,
+        "length": 70,
+        "id": 109780,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4658638,
+            52.5179215
+          ],
+          [
+            13.4655844,
+            52.5173118
+          ]
+        ]
+      },
+      "id": "link-109780"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 17,
+        "startId": 13,
+        "frc": 6,
+        "length": 109,
+        "id": 109781,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4655844,
+            52.5173118
+          ],
+          [
+            13.4651667,
+            52.5163591
+          ]
+        ]
+      },
+      "id": "link-109781"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 18,
+        "startId": 17,
+        "frc": 6,
+        "length": 178,
+        "id": 109782,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4651667,
+            52.5163591
+          ],
+          [
+            13.4644354,
+            52.5149463
+          ],
+          [
+            13.464386,
+            52.5148252
+          ]
+        ]
+      },
+      "id": "link-109782"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 20,
+        "startId": 19,
+        "frc": 6,
+        "length": 192,
+        "id": 109783,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4637853,
+            52.5166159
+          ],
+          [
+            13.4628716,
+            52.5150466
+          ],
+          [
+            13.4628442,
+            52.5149807
+          ]
+        ]
+      },
+      "id": "link-109783"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 21,
+        "startId": 15,
+        "frc": 6,
+        "length": 7,
+        "id": 109790,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4580678,
+            52.5195445
+          ],
+          [
+            13.4581169,
+            52.5194882
+          ]
+        ]
+      },
+      "id": "link-109790"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 22,
+        "startId": 21,
+        "frc": 6,
+        "length": 132,
+        "id": 109791,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4581169,
+            52.5194882
+          ],
+          [
+            13.4599884,
+            52.5191386
+          ]
+        ]
+      },
+      "id": "link-109791"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 23,
+        "startId": 22,
+        "frc": 6,
+        "length": 139,
+        "id": 109792,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4599884,
+            52.5191386
+          ],
+          [
+            13.4619511,
+            52.5187508
+          ]
+        ]
+      },
+      "id": "link-109792"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 24,
+        "startId": 16,
+        "frc": 6,
+        "length": 94,
+        "id": 129357,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4658638,
+            52.5179215
+          ],
+          [
+            13.4669299,
+            52.5177099
+          ],
+          [
+            13.4670275,
+            52.517705
+          ],
+          [
+            13.4671133,
+            52.5177239
+          ],
+          [
+            13.4671734,
+            52.5177627
+          ]
+        ]
+      },
+      "id": "link-129357"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 25,
+        "startId": 24,
+        "frc": 6,
+        "length": 19,
+        "id": 129358,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4671734,
+            52.5177627
+          ],
+          [
+            13.4672351,
+            52.5178446
+          ],
+          [
+            13.4672571,
+            52.5179261
+          ]
+        ]
+      },
+      "id": "link-129358"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 26,
+        "startId": 25,
+        "frc": 6,
+        "length": 97,
+        "id": 129359,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4672571,
+            52.5179261
+          ],
+          [
+            13.4672507,
+            52.5179843
+          ],
+          [
+            13.4672004,
+            52.5180388
+          ],
+          [
+            13.4671219,
+            52.5180761
+          ],
+          [
+            13.4660337,
+            52.5182804
+          ]
+        ]
+      },
+      "id": "link-129359"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 28,
+        "startId": 27,
+        "frc": 6,
+        "length": 16,
+        "id": 244115,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4675,
+            52.514512
+          ],
+          [
+            13.467463,
+            52.5143633
+          ]
+        ]
+      },
+      "id": "link-244115"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 30,
+        "startId": 29,
+        "frc": 6,
+        "length": 31,
+        "id": 580854,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4694532,
+            52.5197829
+          ],
+          [
+            13.4698386,
+            52.5198153
+          ],
+          [
+            13.4699091,
+            52.5198212
+          ]
+        ]
+      },
+      "id": "link-580854"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 32,
+        "startId": 31,
+        "frc": 6,
+        "length": 259,
+        "id": 869554,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4593616,
+            52.5125053
+          ],
+          [
+            13.4608636,
+            52.5143338
+          ],
+          [
+            13.4610713,
+            52.5145974
+          ]
+        ]
+      },
+      "id": "link-869554"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 33,
+        "startId": 32,
+        "frc": 6,
+        "length": 13,
+        "id": 869555,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4610713,
+            52.5145974
+          ],
+          [
+            13.4611548,
+            52.5147052
+          ]
+        ]
+      },
+      "id": "link-869555"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 35,
+        "startId": 34,
+        "frc": 2,
+        "length": 154,
+        "id": 961825,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4601262,
+            52.5151013
+          ],
+          [
+            13.4612721,
+            52.5149835
+          ],
+          [
+            13.4623778,
+            52.5148788
+          ]
+        ]
+      },
+      "id": "link-961825"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 37,
+        "startId": 36,
+        "frc": 2,
+        "length": 333,
+        "id": 961826,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4601915,
+            52.5152482
+          ],
+          [
+            13.4577964,
+            52.5154904
+          ],
+          [
+            13.4569081,
+            52.5155802
+          ],
+          [
+            13.4553269,
+            52.5157401
+          ]
+        ]
+      },
+      "id": "link-961826"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 39,
+        "startId": 38,
+        "frc": 4,
+        "length": 11,
+        "id": 1440992,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4636778,
+            52.5199086
+          ],
+          [
+            13.46384,
+            52.5199217
+          ]
+        ]
+      },
+      "id": "link-1440992"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 40,
+        "startId": 39,
+        "frc": 4,
+        "length": 115,
+        "id": 1440993,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.46384,
+            52.5199217
+          ],
+          [
+            13.4655333,
+            52.5200577
+          ]
+        ]
+      },
+      "id": "link-1440993"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 41,
+        "startId": 23,
+        "frc": 6,
+        "length": 279,
+        "id": 1653135,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4619511,
+            52.5187508
+          ],
+          [
+            13.4659039,
+            52.5180116
+          ]
+        ]
+      },
+      "id": "link-1653135"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 43,
+        "startId": 42,
+        "frc": 6,
+        "length": 279,
+        "id": 1653344,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4659771,
+            52.5181688
+          ],
+          [
+            13.4620337,
+            52.5189155
+          ]
+        ]
+      },
+      "id": "link-1653344"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 39,
+        "startId": 44,
+        "frc": 6,
+        "length": 11,
+        "id": 1844615,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4638238,
+            52.5200205
+          ],
+          [
+            13.46384,
+            52.5199217
+          ]
+        ]
+      },
+      "id": "link-1844615"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 45,
+        "startId": 38,
+        "frc": 6,
+        "length": 30,
+        "id": 2071322,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4636778,
+            52.5199086
+          ],
+          [
+            13.4636855,
+            52.5196353
+          ]
+        ]
+      },
+      "id": "link-2071322"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 45,
+        "startId": 46,
+        "frc": 6,
+        "length": 29,
+        "id": 2071323,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4632681,
+            52.5197096
+          ],
+          [
+            13.4636855,
+            52.5196353
+          ]
+        ]
+      },
+      "id": "link-2071323"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 47,
+        "startId": 45,
+        "frc": 6,
+        "length": 194,
+        "id": 2071324,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4636855,
+            52.5196353
+          ],
+          [
+            13.4664359,
+            52.5191265
+          ]
+        ]
+      },
+      "id": "link-2071324"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 48,
+        "startId": 47,
+        "frc": 6,
+        "length": 194,
+        "id": 2071325,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664359,
+            52.5191265
+          ],
+          [
+            13.4691926,
+            52.5186312
+          ]
+        ]
+      },
+      "id": "link-2071325"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 50,
+        "startId": 49,
+        "frc": 6,
+        "length": 199,
+        "id": 2270106,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4717725,
+            52.5171749
+          ],
+          [
+            13.4716809,
+            52.5171334
+          ],
+          [
+            13.4714815,
+            52.5171697
+          ],
+          [
+            13.4709814,
+            52.5172609
+          ],
+          [
+            13.4705881,
+            52.5173326
+          ],
+          [
+            13.4702575,
+            52.5173936
+          ],
+          [
+            13.4696134,
+            52.5175123
+          ],
+          [
+            13.4692614,
+            52.5175772
+          ],
+          [
+            13.4689664,
+            52.5176316
+          ]
+        ]
+      },
+      "id": "link-2270106"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 29,
+        "startId": 51,
+        "frc": 6,
+        "length": 32,
+        "id": 2711304,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4695196,
+            52.5200682
+          ],
+          [
+            13.4694532,
+            52.5197829
+          ]
+        ]
+      },
+      "id": "link-2711304"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 48,
+        "startId": 29,
+        "frc": 6,
+        "length": 129,
+        "id": 2711305,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4694532,
+            52.5197829
+          ],
+          [
+            13.4691926,
+            52.5186312
+          ]
+        ]
+      },
+      "id": "link-2711305"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 50,
+        "startId": 48,
+        "frc": 6,
+        "length": 112,
+        "id": 2711306,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4691926,
+            52.5186312
+          ],
+          [
+            13.4689664,
+            52.5176316
+          ]
+        ]
+      },
+      "id": "link-2711306"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 52,
+        "startId": 50,
+        "frc": 6,
+        "length": 18,
+        "id": 2711307,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4689664,
+            52.5176316
+          ],
+          [
+            13.4689411,
+            52.5175517
+          ],
+          [
+            13.4689136,
+            52.5174726
+          ]
+        ]
+      },
+      "id": "link-2711307"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 53,
+        "startId": 52,
+        "frc": 6,
+        "length": 86,
+        "id": 2711308,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4689136,
+            52.5174726
+          ],
+          [
+            13.4685852,
+            52.5168407
+          ],
+          [
+            13.4684887,
+            52.5168015
+          ],
+          [
+            13.4684334,
+            52.5167789
+          ]
+        ]
+      },
+      "id": "link-2711308"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 55,
+        "startId": 54,
+        "frc": 4,
+        "length": 250,
+        "id": 2814372,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4578115,
+            52.5127857
+          ],
+          [
+            13.4573712,
+            52.5129215
+          ],
+          [
+            13.4548647,
+            52.5137703
+          ],
+          [
+            13.4545609,
+            52.513858
+          ]
+        ]
+      },
+      "id": "link-2814372"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 57,
+        "startId": 56,
+        "frc": 6,
+        "length": 279,
+        "id": 3227046,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4686563,
+            52.5167401
+          ],
+          [
+            13.4726201,
+            52.5160233
+          ]
+        ]
+      },
+      "id": "link-3227046"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 53,
+        "startId": 13,
+        "frc": 6,
+        "length": 201,
+        "id": 3227047,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4655844,
+            52.5173118
+          ],
+          [
+            13.4666,
+            52.5171188
+          ],
+          [
+            13.4684334,
+            52.5167789
+          ]
+        ]
+      },
+      "id": "link-3227047"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 2,
+        "startId": 58,
+        "frc": 6,
+        "length": 51,
+        "id": 3622025,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4572516,
+            52.5149212
+          ],
+          [
+            13.457386,
+            52.5153814
+          ]
+        ]
+      },
+      "id": "link-3622025"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 59,
+        "startId": 58,
+        "frc": 6,
+        "length": 124,
+        "id": 3622026,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4572516,
+            52.5149212
+          ],
+          [
+            13.4577955,
+            52.5148755
+          ],
+          [
+            13.4579624,
+            52.5149461
+          ],
+          [
+            13.4590401,
+            52.5148416
+          ]
+        ]
+      },
+      "id": "link-3622026"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 61,
+        "startId": 60,
+        "frc": 6,
+        "length": 17,
+        "id": 3622210,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.460514,
+            52.5159006
+          ],
+          [
+            13.4602666,
+            52.5159453
+          ]
+        ]
+      },
+      "id": "link-3622210"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 63,
+        "startId": 62,
+        "frc": 2,
+        "length": 171,
+        "id": 3863569,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4708386,
+            52.5141744
+          ],
+          [
+            13.4706595,
+            52.5141925
+          ],
+          [
+            13.4699891,
+            52.5142601
+          ],
+          [
+            13.4695929,
+            52.5143
+          ],
+          [
+            13.468332,
+            52.514428
+          ]
+        ]
+      },
+      "id": "link-3863569"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 52,
+        "startId": 24,
+        "frc": 6,
+        "length": 122,
+        "id": 4035943,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4671734,
+            52.5177627
+          ],
+          [
+            13.4689136,
+            52.5174726
+          ]
+        ]
+      },
+      "id": "link-4035943"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 25,
+        "startId": 50,
+        "frc": 6,
+        "length": 120,
+        "id": 4035944,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4689664,
+            52.5176316
+          ],
+          [
+            13.4672571,
+            52.5179261
+          ]
+        ]
+      },
+      "id": "link-4035944"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 65,
+        "startId": 64,
+        "frc": 6,
+        "length": 178,
+        "id": 4058679,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4670479,
+            52.5160273
+          ],
+          [
+            13.4669765,
+            52.5159637
+          ],
+          [
+            13.4663576,
+            52.5154126
+          ],
+          [
+            13.4661867,
+            52.5153356
+          ],
+          [
+            13.4657316,
+            52.5149464
+          ],
+          [
+            13.4656691,
+            52.5146948
+          ]
+        ]
+      },
+      "id": "link-4058679"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 36,
+        "startId": 34,
+        "frc": 4,
+        "length": 16,
+        "id": 4232179,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4601262,
+            52.5151013
+          ],
+          [
+            13.4601915,
+            52.5152482
+          ]
+        ]
+      },
+      "id": "link-4232179"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 66,
+        "startId": 8,
+        "frc": 6,
+        "length": 25,
+        "id": 4921654,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4630931,
+            52.5144057
+          ],
+          [
+            13.4631948,
+            52.5143804
+          ],
+          [
+            13.4633611,
+            52.5143383
+          ],
+          [
+            13.4634379,
+            52.5143199
+          ]
+        ]
+      },
+      "id": "link-4921654"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 67,
+        "startId": 11,
+        "frc": 6,
+        "length": 140,
+        "id": 4925290,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4571122,
+            52.5177995
+          ],
+          [
+            13.4572213,
+            52.5177806
+          ],
+          [
+            13.4581994,
+            52.5176116
+          ],
+          [
+            13.4591042,
+            52.5174553
+          ]
+        ]
+      },
+      "id": "link-4925290"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 68,
+        "startId": 67,
+        "frc": 6,
+        "length": 142,
+        "id": 4925291,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4591042,
+            52.5174553
+          ],
+          [
+            13.4600556,
+            52.5172924
+          ],
+          [
+            13.4611206,
+            52.5170944
+          ]
+        ]
+      },
+      "id": "link-4925291"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 64,
+        "startId": 69,
+        "frc": 6,
+        "length": 40,
+        "id": 4925292,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664717,
+            52.5161278
+          ],
+          [
+            13.4670479,
+            52.5160273
+          ]
+        ]
+      },
+      "id": "link-4925292"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 70,
+        "startId": 64,
+        "frc": 6,
+        "length": 74,
+        "id": 4925293,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4670479,
+            52.5160273
+          ],
+          [
+            13.4681029,
+            52.5158439
+          ]
+        ]
+      },
+      "id": "link-4925293"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 71,
+        "startId": 70,
+        "frc": 6,
+        "length": 158,
+        "id": 4925294,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4681029,
+            52.5158439
+          ],
+          [
+            13.4686913,
+            52.5157404
+          ],
+          [
+            13.4703464,
+            52.5154417
+          ]
+        ]
+      },
+      "id": "link-4925294"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 73,
+        "startId": 72,
+        "frc": 6,
+        "length": 12,
+        "id": 4957478,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4599436,
+            52.51489
+          ],
+          [
+            13.4600972,
+            52.5148327
+          ]
+        ]
+      },
+      "id": "link-4957478"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 74,
+        "startId": 73,
+        "frc": 6,
+        "length": 12,
+        "id": 4957479,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4600972,
+            52.5148327
+          ],
+          [
+            13.4602568,
+            52.5147763
+          ]
+        ]
+      },
+      "id": "link-4957479"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 33,
+        "startId": 74,
+        "frc": 6,
+        "length": 63,
+        "id": 4957480,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4602568,
+            52.5147763
+          ],
+          [
+            13.4604278,
+            52.5147241
+          ],
+          [
+            13.4605719,
+            52.5147376
+          ],
+          [
+            13.4606999,
+            52.5147553
+          ],
+          [
+            13.4607292,
+            52.5147593
+          ],
+          [
+            13.4608841,
+            52.514737
+          ],
+          [
+            13.4611548,
+            52.5147052
+          ]
+        ]
+      },
+      "id": "link-4957480"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 72,
+        "startId": 34,
+        "frc": 6,
+        "length": 26,
+        "id": 4993081,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4601262,
+            52.5151013
+          ],
+          [
+            13.460053,
+            52.514996
+          ],
+          [
+            13.4599436,
+            52.51489
+          ]
+        ]
+      },
+      "id": "link-4993081"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 75,
+        "startId": 72,
+        "frc": 6,
+        "length": 69,
+        "id": 4993082,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4599436,
+            52.51489
+          ],
+          [
+            13.459407,
+            52.5143601
+          ]
+        ]
+      },
+      "id": "link-4993082"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 54,
+        "startId": 75,
+        "frc": 6,
+        "length": 205,
+        "id": 4993083,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.459407,
+            52.5143601
+          ],
+          [
+            13.4592404,
+            52.5141953
+          ],
+          [
+            13.4578115,
+            52.5127857
+          ]
+        ]
+      },
+      "id": "link-4993083"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 77,
+        "startId": 76,
+        "frc": 6,
+        "length": 196,
+        "id": 4995388,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.468463,
+            52.5125412
+          ],
+          [
+            13.4685538,
+            52.5126506
+          ],
+          [
+            13.4692546,
+            52.5133555
+          ],
+          [
+            13.4693353,
+            52.5134383
+          ],
+          [
+            13.4693589,
+            52.5134753
+          ],
+          [
+            13.4696325,
+            52.5141418
+          ]
+        ]
+      },
+      "id": "link-4995388"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 43,
+        "startId": 78,
+        "frc": 4,
+        "length": 109,
+        "id": 4997410,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4624949,
+            52.519861
+          ],
+          [
+            13.4620459,
+            52.5189405
+          ],
+          [
+            13.4620337,
+            52.5189155
+          ]
+        ]
+      },
+      "id": "link-4997410"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 23,
+        "startId": 43,
+        "frc": 4,
+        "length": 19,
+        "id": 4997411,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4620337,
+            52.5189155
+          ],
+          [
+            13.4619846,
+            52.5188177
+          ],
+          [
+            13.4619511,
+            52.5187508
+          ]
+        ]
+      },
+      "id": "link-4997411"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 80,
+        "startId": 79,
+        "frc": 6,
+        "length": 39,
+        "id": 5104155,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4567043,
+            52.516356
+          ],
+          [
+            13.4567727,
+            52.5162689
+          ],
+          [
+            13.4570226,
+            52.5162444
+          ],
+          [
+            13.4571604,
+            52.5163129
+          ]
+        ]
+      },
+      "id": "link-5104155"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 82,
+        "startId": 81,
+        "frc": 6,
+        "length": 37,
+        "id": 5104156,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4578996,
+            52.5162418
+          ],
+          [
+            13.4580183,
+            52.516158
+          ],
+          [
+            13.4582258,
+            52.5161426
+          ],
+          [
+            13.4583666,
+            52.5161997
+          ]
+        ]
+      },
+      "id": "link-5104156"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 15,
+        "startId": 83,
+        "frc": 6,
+        "length": 146,
+        "id": 5212268,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4559287,
+            52.5193482
+          ],
+          [
+            13.4564007,
+            52.5193863
+          ],
+          [
+            13.4574154,
+            52.5194681
+          ],
+          [
+            13.4579384,
+            52.5195103
+          ],
+          [
+            13.4580678,
+            52.5195445
+          ]
+        ]
+      },
+      "id": "link-5212268"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 12,
+        "startId": 23,
+        "frc": 4,
+        "length": 82,
+        "id": 5359424,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4619511,
+            52.5187508
+          ],
+          [
+            13.4615934,
+            52.5180374
+          ]
+        ]
+      },
+      "id": "link-5359424"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 68,
+        "startId": 12,
+        "frc": 4,
+        "length": 109,
+        "id": 5359425,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4615934,
+            52.5180374
+          ],
+          [
+            13.4611206,
+            52.5170944
+          ]
+        ]
+      },
+      "id": "link-5359425"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 60,
+        "startId": 68,
+        "frc": 4,
+        "length": 138,
+        "id": 5359426,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4611206,
+            52.5170944
+          ],
+          [
+            13.460514,
+            52.5159006
+          ]
+        ]
+      },
+      "id": "link-5359426"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 84,
+        "startId": 60,
+        "frc": 4,
+        "length": 31,
+        "id": 5359427,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.460514,
+            52.5159006
+          ],
+          [
+            13.4603798,
+            52.5156268
+          ]
+        ]
+      },
+      "id": "link-5359427"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 78,
+        "startId": 85,
+        "frc": 4,
+        "length": 51,
+        "id": 5530025,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4617642,
+            52.5199904
+          ],
+          [
+            13.4623151,
+            52.5198918
+          ],
+          [
+            13.4624349,
+            52.5198705
+          ],
+          [
+            13.4624949,
+            52.519861
+          ]
+        ]
+      },
+      "id": "link-5530025"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 86,
+        "startId": 22,
+        "frc": 6,
+        "length": 67,
+        "id": 5530112,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4599884,
+            52.5191386
+          ],
+          [
+            13.4596856,
+            52.5185621
+          ]
+        ]
+      },
+      "id": "link-5530112"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 67,
+        "startId": 86,
+        "frc": 6,
+        "length": 129,
+        "id": 5530113,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4596856,
+            52.5185621
+          ],
+          [
+            13.4591042,
+            52.5174553
+          ]
+        ]
+      },
+      "id": "link-5530113"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 88,
+        "startId": 87,
+        "frc": 6,
+        "length": 32,
+        "id": 5707432,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4614437,
+            52.5158342
+          ],
+          [
+            13.4617042,
+            52.5160751
+          ]
+        ]
+      },
+      "id": "link-5707432"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 87,
+        "startId": 89,
+        "frc": 6,
+        "length": 14,
+        "id": 5707433,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4613231,
+            52.5157223
+          ],
+          [
+            13.4614437,
+            52.5158342
+          ]
+        ]
+      },
+      "id": "link-5707433"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 91,
+        "startId": 90,
+        "frc": 6,
+        "length": 13,
+        "id": 5707434,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4609064,
+            52.5151775
+          ],
+          [
+            13.4609408,
+            52.5152926
+          ]
+        ]
+      },
+      "id": "link-5707434"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 93,
+        "startId": 92,
+        "frc": 6,
+        "length": 7,
+        "id": 5707435,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4618955,
+            52.5162491
+          ],
+          [
+            13.4619574,
+            52.5163044
+          ]
+        ]
+      },
+      "id": "link-5707435"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 92,
+        "startId": 88,
+        "frc": 6,
+        "length": 23,
+        "id": 5707436,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4617042,
+            52.5160751
+          ],
+          [
+            13.4618955,
+            52.5162491
+          ]
+        ]
+      },
+      "id": "link-5707436"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 89,
+        "startId": 94,
+        "frc": 6,
+        "length": 41,
+        "id": 5707437,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4609759,
+            52.5154164
+          ],
+          [
+            13.4613231,
+            52.5157223
+          ]
+        ]
+      },
+      "id": "link-5707437"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 94,
+        "startId": 91,
+        "frc": 6,
+        "length": 13,
+        "id": 5707438,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4609408,
+            52.5152926
+          ],
+          [
+            13.4609759,
+            52.5154164
+          ]
+        ]
+      },
+      "id": "link-5707438"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 96,
+        "startId": 95,
+        "frc": 6,
+        "length": 112,
+        "id": 5707439,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4630579,
+            52.5167465
+          ],
+          [
+            13.4626303,
+            52.5162849
+          ],
+          [
+            13.4622184,
+            52.5158742
+          ]
+        ]
+      },
+      "id": "link-5707439"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 98,
+        "startId": 97,
+        "frc": 6,
+        "length": 12,
+        "id": 6106081,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664872,
+            52.5146131
+          ],
+          [
+            13.4665181,
+            52.5147222
+          ]
+        ]
+      },
+      "id": "link-6106081"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 99,
+        "startId": 98,
+        "frc": 6,
+        "length": 12,
+        "id": 6106085,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4665181,
+            52.5147222
+          ],
+          [
+            13.4665422,
+            52.5148305
+          ]
+        ]
+      },
+      "id": "link-6106085"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 48,
+        "startId": 100,
+        "frc": 6,
+        "length": 124,
+        "id": 6306686,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4709624,
+            52.5183183
+          ],
+          [
+            13.4708056,
+            52.5183415
+          ],
+          [
+            13.4698519,
+            52.5185128
+          ],
+          [
+            13.4691926,
+            52.5186312
+          ]
+        ]
+      },
+      "id": "link-6306686"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 101,
+        "startId": 18,
+        "frc": 6,
+        "length": 17,
+        "id": 6770339,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.464386,
+            52.5148252
+          ],
+          [
+            13.4643394,
+            52.5146736
+          ]
+        ]
+      },
+      "id": "link-6770339"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 102,
+        "startId": 20,
+        "frc": 6,
+        "length": 16,
+        "id": 6770340,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4628442,
+            52.5149807
+          ],
+          [
+            13.4627936,
+            52.5148339
+          ]
+        ]
+      },
+      "id": "link-6770340"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 103,
+        "startId": 33,
+        "frc": 6,
+        "length": 54,
+        "id": 6828300,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4611548,
+            52.5147052
+          ],
+          [
+            13.4619458,
+            52.5146163
+          ]
+        ]
+      },
+      "id": "link-6828300"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 32,
+        "startId": 104,
+        "frc": 6,
+        "length": 66,
+        "id": 6828301,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4617983,
+            52.5143111
+          ],
+          [
+            13.4618492,
+            52.5143813
+          ],
+          [
+            13.4610713,
+            52.5145974
+          ]
+        ]
+      },
+      "id": "link-6828301"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 58,
+        "startId": 105,
+        "frc": 6,
+        "length": 153,
+        "id": 7020005,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4551048,
+            52.5152531
+          ],
+          [
+            13.455726,
+            52.5151832
+          ],
+          [
+            13.4557844,
+            52.5151614
+          ],
+          [
+            13.4558812,
+            52.5151514
+          ],
+          [
+            13.4566041,
+            52.5150769
+          ],
+          [
+            13.4567808,
+            52.5149625
+          ],
+          [
+            13.4572516,
+            52.5149212
+          ]
+        ]
+      },
+      "id": "link-7020005"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 106,
+        "startId": 5,
+        "frc": 6,
+        "length": 12,
+        "id": 7144579,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4645716,
+            52.5142805
+          ],
+          [
+            13.4644002,
+            52.5143113
+          ]
+        ]
+      },
+      "id": "link-7144579"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 107,
+        "startId": 106,
+        "frc": 6,
+        "length": 12,
+        "id": 7144580,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4644002,
+            52.5143113
+          ],
+          [
+            13.4642308,
+            52.5143447
+          ]
+        ]
+      },
+      "id": "link-7144580"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 66,
+        "startId": 108,
+        "frc": 6,
+        "length": 22,
+        "id": 7144581,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4635899,
+            52.5144763
+          ],
+          [
+            13.4634839,
+            52.5143115
+          ],
+          [
+            13.4634379,
+            52.5143199
+          ]
+        ]
+      },
+      "id": "link-7144581"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 108,
+        "startId": 107,
+        "frc": 6,
+        "length": 47,
+        "id": 7144582,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4642308,
+            52.5143447
+          ],
+          [
+            13.4641899,
+            52.5143861
+          ],
+          [
+            13.4640691,
+            52.5144206
+          ],
+          [
+            13.4639305,
+            52.5144357
+          ],
+          [
+            13.4635899,
+            52.5144763
+          ]
+        ]
+      },
+      "id": "link-7144582"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 109,
+        "startId": 21,
+        "frc": 6,
+        "length": 55,
+        "id": 7292028,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4581169,
+            52.5194882
+          ],
+          [
+            13.4579174,
+            52.5191385
+          ],
+          [
+            13.4578493,
+            52.5190142
+          ]
+        ]
+      },
+      "id": "link-7292028"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 110,
+        "startId": 109,
+        "frc": 6,
+        "length": 35,
+        "id": 7292029,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4578493,
+            52.5190142
+          ],
+          [
+            13.4576677,
+            52.518717
+          ]
+        ]
+      },
+      "id": "link-7292029"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 11,
+        "startId": 110,
+        "frc": 6,
+        "length": 108,
+        "id": 7292030,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4576677,
+            52.518717
+          ],
+          [
+            13.4571122,
+            52.5177995
+          ]
+        ]
+      },
+      "id": "link-7292030"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 111,
+        "startId": 11,
+        "frc": 6,
+        "length": 132,
+        "id": 7292031,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4571122,
+            52.5177995
+          ],
+          [
+            13.4560582,
+            52.5167925
+          ]
+        ]
+      },
+      "id": "link-7292031"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 97,
+        "startId": 27,
+        "frc": 2,
+        "length": 69,
+        "id": 7430340,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4675,
+            52.514512
+          ],
+          [
+            13.46733,
+            52.514529
+          ],
+          [
+            13.4667114,
+            52.5145908
+          ],
+          [
+            13.4664872,
+            52.5146131
+          ]
+        ]
+      },
+      "id": "link-7430340"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 65,
+        "startId": 97,
+        "frc": 2,
+        "length": 56,
+        "id": 7430341,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664872,
+            52.5146131
+          ],
+          [
+            13.4660607,
+            52.5146563
+          ],
+          [
+            13.465989,
+            52.5146635
+          ],
+          [
+            13.4656691,
+            52.5146948
+          ]
+        ]
+      },
+      "id": "link-7430341"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 112,
+        "startId": 65,
+        "frc": 2,
+        "length": 13,
+        "id": 7430342,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4656691,
+            52.5146948
+          ],
+          [
+            13.4655954,
+            52.5147032
+          ],
+          [
+            13.4654654,
+            52.5147163
+          ]
+        ]
+      },
+      "id": "link-7430342"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 18,
+        "startId": 112,
+        "frc": 2,
+        "length": 74,
+        "id": 7430343,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4654654,
+            52.5147163
+          ],
+          [
+            13.4645799,
+            52.5148056
+          ],
+          [
+            13.464544,
+            52.5148092
+          ],
+          [
+            13.464386,
+            52.5148252
+          ]
+        ]
+      },
+      "id": "link-7430343"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 113,
+        "startId": 18,
+        "frc": 2,
+        "length": 32,
+        "id": 7430344,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.464386,
+            52.5148252
+          ],
+          [
+            13.463911,
+            52.5148731
+          ]
+        ]
+      },
+      "id": "link-7430344"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 27,
+        "startId": 63,
+        "frc": 2,
+        "length": 57,
+        "id": 7430346,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.468332,
+            52.514428
+          ],
+          [
+            13.4677311,
+            52.5144887
+          ],
+          [
+            13.4676686,
+            52.514495
+          ],
+          [
+            13.4675,
+            52.514512
+          ]
+        ]
+      },
+      "id": "link-7430346"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 34,
+        "startId": 3,
+        "frc": 2,
+        "length": 78,
+        "id": 7430347,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4589756,
+            52.515216
+          ],
+          [
+            13.4598572,
+            52.5151281
+          ],
+          [
+            13.4601262,
+            52.5151013
+          ]
+        ]
+      },
+      "id": "link-7430347"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 28,
+        "startId": 114,
+        "frc": 2,
+        "length": 51,
+        "id": 7430348,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4667149,
+            52.5144364
+          ],
+          [
+            13.4672304,
+            52.514386
+          ],
+          [
+            13.4672899,
+            52.5143802
+          ],
+          [
+            13.467463,
+            52.5143633
+          ]
+        ]
+      },
+      "id": "link-7430348"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 101,
+        "startId": 7,
+        "frc": 2,
+        "length": 68,
+        "id": 7430351,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4633349,
+            52.5147774
+          ],
+          [
+            13.4640326,
+            52.5147048
+          ],
+          [
+            13.4641464,
+            52.514693
+          ],
+          [
+            13.4643394,
+            52.5146736
+          ]
+        ]
+      },
+      "id": "link-7430351"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 90,
+        "startId": 115,
+        "frc": 2,
+        "length": 22,
+        "id": 7430352,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4612277,
+            52.5151437
+          ],
+          [
+            13.4609064,
+            52.5151775
+          ]
+        ]
+      },
+      "id": "link-7430352"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 36,
+        "startId": 90,
+        "frc": 2,
+        "length": 49,
+        "id": 7430353,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4609064,
+            52.5151775
+          ],
+          [
+            13.4604432,
+            52.5152233
+          ],
+          [
+            13.4601915,
+            52.5152482
+          ]
+        ]
+      },
+      "id": "link-7430353"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 4,
+        "startId": 101,
+        "frc": 2,
+        "length": 27,
+        "id": 7430360,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4643394,
+            52.5146736
+          ],
+          [
+            13.4645006,
+            52.5146575
+          ],
+          [
+            13.4647406,
+            52.5146335
+          ]
+        ]
+      },
+      "id": "link-7430360"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 116,
+        "startId": 4,
+        "frc": 2,
+        "length": 95,
+        "id": 7430361,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4647406,
+            52.5146335
+          ],
+          [
+            13.46541,
+            52.5145667
+          ],
+          [
+            13.4660179,
+            52.514506
+          ],
+          [
+            13.4661309,
+            52.5144947
+          ]
+        ]
+      },
+      "id": "link-7430361"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 114,
+        "startId": 116,
+        "frc": 2,
+        "length": 40,
+        "id": 7430362,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4661309,
+            52.5144947
+          ],
+          [
+            13.4667149,
+            52.5144364
+          ]
+        ]
+      },
+      "id": "link-7430362"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 77,
+        "startId": 28,
+        "frc": 2,
+        "length": 148,
+        "id": 7430363,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.467463,
+            52.5143633
+          ],
+          [
+            13.4676329,
+            52.5143459
+          ],
+          [
+            13.4695415,
+            52.5141509
+          ],
+          [
+            13.4696325,
+            52.5141418
+          ]
+        ]
+      },
+      "id": "link-7430363"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 36,
+        "startId": 84,
+        "frc": 4,
+        "length": 43,
+        "id": 7430367,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4603798,
+            52.5156268
+          ],
+          [
+            13.4603536,
+            52.5155737
+          ],
+          [
+            13.4602685,
+            52.5154028
+          ],
+          [
+            13.4601915,
+            52.5152482
+          ]
+        ]
+      },
+      "id": "link-7430367"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 118,
+        "startId": 117,
+        "frc": 6,
+        "length": 34,
+        "id": 7516883,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4580688,
+            52.5189743
+          ],
+          [
+            13.4579134,
+            52.5186781
+          ]
+        ]
+      },
+      "id": "link-7516883"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 118,
+        "startId": 110,
+        "frc": 6,
+        "length": 17,
+        "id": 7516884,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4576677,
+            52.518717
+          ],
+          [
+            13.4579134,
+            52.5186781
+          ]
+        ]
+      },
+      "id": "link-7516884"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 119,
+        "startId": 118,
+        "frc": 6,
+        "length": 10,
+        "id": 7516885,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4579134,
+            52.5186781
+          ],
+          [
+            13.4580594,
+            52.5186534
+          ]
+        ]
+      },
+      "id": "link-7516885"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 117,
+        "startId": 109,
+        "frc": 6,
+        "length": 15,
+        "id": 7516886,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4578493,
+            52.5190142
+          ],
+          [
+            13.4580688,
+            52.5189743
+          ]
+        ]
+      },
+      "id": "link-7516886"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 120,
+        "startId": 117,
+        "frc": 6,
+        "length": 48,
+        "id": 7516887,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4580688,
+            52.5189743
+          ],
+          [
+            13.4587602,
+            52.5188493
+          ]
+        ]
+      },
+      "id": "link-7516887"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 122,
+        "startId": 121,
+        "frc": 6,
+        "length": 75,
+        "id": 7519155,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4600694,
+            52.5159805
+          ],
+          [
+            13.4595815,
+            52.5160535
+          ],
+          [
+            13.4594091,
+            52.5161856
+          ],
+          [
+            13.4592492,
+            52.5162356
+          ],
+          [
+            13.4590979,
+            52.5162475
+          ]
+        ]
+      },
+      "id": "link-7519155"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 123,
+        "startId": 122,
+        "frc": 6,
+        "length": 36,
+        "id": 7519156,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4590979,
+            52.5162475
+          ],
+          [
+            13.4585643,
+            52.5162981
+          ]
+        ]
+      },
+      "id": "link-7519156"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 82,
+        "startId": 123,
+        "frc": 6,
+        "length": 17,
+        "id": 7519157,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4585643,
+            52.5162981
+          ],
+          [
+            13.4584163,
+            52.5162227
+          ],
+          [
+            13.4583666,
+            52.5161997
+          ]
+        ]
+      },
+      "id": "link-7519157"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 81,
+        "startId": 82,
+        "frc": 6,
+        "length": 31,
+        "id": 7519158,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4583666,
+            52.5161997
+          ],
+          [
+            13.4578996,
+            52.5162418
+          ]
+        ]
+      },
+      "id": "link-7519158"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 80,
+        "startId": 81,
+        "frc": 6,
+        "length": 50,
+        "id": 7519159,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4578996,
+            52.5162418
+          ],
+          [
+            13.457813,
+            52.5162503
+          ],
+          [
+            13.4572559,
+            52.5163045
+          ],
+          [
+            13.4571604,
+            52.5163129
+          ]
+        ]
+      },
+      "id": "link-7519159"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 124,
+        "startId": 80,
+        "frc": 6,
+        "length": 11,
+        "id": 7519160,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4571604,
+            52.5163129
+          ],
+          [
+            13.4569887,
+            52.5163301
+          ]
+        ]
+      },
+      "id": "link-7519160"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 121,
+        "startId": 61,
+        "frc": 6,
+        "length": 13,
+        "id": 7519163,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4602666,
+            52.5159453
+          ],
+          [
+            13.4600694,
+            52.5159805
+          ]
+        ]
+      },
+      "id": "link-7519163"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 7,
+        "startId": 102,
+        "frc": 2,
+        "length": 37,
+        "id": 7531947,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4627936,
+            52.5148339
+          ],
+          [
+            13.4631042,
+            52.5148015
+          ],
+          [
+            13.4633349,
+            52.5147774
+          ]
+        ]
+      },
+      "id": "link-7531947"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 20,
+        "startId": 113,
+        "frc": 2,
+        "length": 73,
+        "id": 7531948,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.463911,
+            52.5148731
+          ],
+          [
+            13.4631576,
+            52.5149491
+          ],
+          [
+            13.4628442,
+            52.5149807
+          ]
+        ]
+      },
+      "id": "link-7531948"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 115,
+        "startId": 20,
+        "frc": 2,
+        "length": 110,
+        "id": 7531949,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4628442,
+            52.5149807
+          ],
+          [
+            13.4624159,
+            52.5150239
+          ],
+          [
+            13.4615035,
+            52.5151159
+          ],
+          [
+            13.4612277,
+            52.5151437
+          ]
+        ]
+      },
+      "id": "link-7531949"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 102,
+        "startId": 35,
+        "frc": 2,
+        "length": 28,
+        "id": 7531950,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4623778,
+            52.5148788
+          ],
+          [
+            13.4625159,
+            52.5148639
+          ],
+          [
+            13.4627936,
+            52.5148339
+          ]
+        ]
+      },
+      "id": "link-7531950"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 122,
+        "startId": 125,
+        "frc": 6,
+        "length": 98,
+        "id": 8199208,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4598686,
+            52.5170028
+          ],
+          [
+            13.4590979,
+            52.5162475
+          ]
+        ]
+      },
+      "id": "link-8199208"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 127,
+        "startId": 126,
+        "frc": 6,
+        "length": 16,
+        "id": 8323953,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4659827,
+            52.5153731
+          ],
+          [
+            13.4660543,
+            52.5154321
+          ],
+          [
+            13.4661547,
+            52.5153925
+          ]
+        ]
+      },
+      "id": "link-8323953"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 129,
+        "startId": 128,
+        "frc": 6,
+        "length": 9,
+        "id": 8323955,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4658069,
+            52.5152145
+          ],
+          [
+            13.4658863,
+            52.5152834
+          ]
+        ]
+      },
+      "id": "link-8323955"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 128,
+        "startId": 130,
+        "frc": 6,
+        "length": 11,
+        "id": 8323956,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4656961,
+            52.5151315
+          ],
+          [
+            13.4658069,
+            52.5152145
+          ]
+        ]
+      },
+      "id": "link-8323956"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 131,
+        "startId": 130,
+        "frc": 6,
+        "length": 24,
+        "id": 8323957,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4656961,
+            52.5151315
+          ],
+          [
+            13.4655742,
+            52.5150353
+          ],
+          [
+            13.4655257,
+            52.5149424
+          ]
+        ]
+      },
+      "id": "link-8323957"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 131,
+        "startId": 132,
+        "frc": 6,
+        "length": 13,
+        "id": 8323958,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4654955,
+            52.5148269
+          ],
+          [
+            13.4655257,
+            52.5149424
+          ]
+        ]
+      },
+      "id": "link-8323958"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 126,
+        "startId": 129,
+        "frc": 6,
+        "length": 11,
+        "id": 8323959,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4658863,
+            52.5152834
+          ],
+          [
+            13.4659827,
+            52.5153731
+          ]
+        ]
+      },
+      "id": "link-8323959"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 132,
+        "startId": 112,
+        "frc": 6,
+        "length": 12,
+        "id": 8323961,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4654654,
+            52.5147163
+          ],
+          [
+            13.4654884,
+            52.5148008
+          ],
+          [
+            13.4654955,
+            52.5148269
+          ]
+        ]
+      },
+      "id": "link-8323961"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 133,
+        "startId": 86,
+        "frc": 6,
+        "length": 41,
+        "id": 8345024,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4596856,
+            52.5185621
+          ],
+          [
+            13.4602779,
+            52.5184519
+          ]
+        ]
+      },
+      "id": "link-8345024"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 134,
+        "startId": 134,
+        "frc": 6,
+        "length": 199,
+        "id": 8345025,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4587361,
+            52.516543
+          ],
+          [
+            13.4582927,
+            52.5167004
+          ],
+          [
+            13.4584735,
+            52.5170611
+          ],
+          [
+            13.4586339,
+            52.5172162
+          ],
+          [
+            13.4591317,
+            52.5170288
+          ],
+          [
+            13.4591629,
+            52.5169915
+          ],
+          [
+            13.4591639,
+            52.5169456
+          ],
+          [
+            13.4587361,
+            52.516543
+          ]
+        ]
+      },
+      "id": "link-8345025"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 123,
+        "startId": 134,
+        "frc": 6,
+        "length": 31,
+        "id": 8345026,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4587361,
+            52.516543
+          ],
+          [
+            13.4585385,
+            52.5163402
+          ],
+          [
+            13.4585643,
+            52.5162981
+          ]
+        ]
+      },
+      "id": "link-8345026"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 38,
+        "startId": 78,
+        "frc": 4,
+        "length": 80,
+        "id": 8354778,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4624949,
+            52.519861
+          ],
+          [
+            13.4626161,
+            52.5198446
+          ],
+          [
+            13.4627309,
+            52.5198386
+          ],
+          [
+            13.4636778,
+            52.5199086
+          ]
+        ]
+      },
+      "id": "link-8354778"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 135,
+        "startId": 116,
+        "frc": 6,
+        "length": 188,
+        "id": 8679353,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4661309,
+            52.5144947
+          ],
+          [
+            13.4656389,
+            52.5128301
+          ]
+        ]
+      },
+      "id": "link-8679353"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 69,
+        "startId": 136,
+        "frc": 6,
+        "length": 8,
+        "id": 8717173,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4663561,
+            52.5161471
+          ],
+          [
+            13.4664717,
+            52.5161278
+          ]
+        ]
+      },
+      "id": "link-8717173"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 95,
+        "startId": 68,
+        "frc": 6,
+        "length": 136,
+        "id": 8717174,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4611206,
+            52.5170944
+          ],
+          [
+            13.4630579,
+            52.5167465
+          ]
+        ]
+      },
+      "id": "link-8717174"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 19,
+        "startId": 95,
+        "frc": 6,
+        "length": 51,
+        "id": 8717175,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4630579,
+            52.5167465
+          ],
+          [
+            13.4637853,
+            52.5166159
+          ]
+        ]
+      },
+      "id": "link-8717175"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 17,
+        "startId": 19,
+        "frc": 6,
+        "length": 97,
+        "id": 8717176,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4637853,
+            52.5166159
+          ],
+          [
+            13.4651667,
+            52.5163591
+          ]
+        ]
+      },
+      "id": "link-8717176"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 136,
+        "startId": 17,
+        "frc": 6,
+        "length": 83,
+        "id": 8717177,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4651667,
+            52.5163591
+          ],
+          [
+            13.4663561,
+            52.5161471
+          ]
+        ]
+      },
+      "id": "link-8717177"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 28,
+        "startId": 137,
+        "frc": 6,
+        "length": 188,
+        "id": 8928196,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4669903,
+            52.5126895
+          ],
+          [
+            13.4670145,
+            52.5127749
+          ],
+          [
+            13.4674263,
+            52.5142262
+          ],
+          [
+            13.4674471,
+            52.5142997
+          ],
+          [
+            13.467463,
+            52.5143633
+          ]
+        ]
+      },
+      "id": "link-8928196"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 139,
+        "startId": 138,
+        "frc": 6,
+        "length": 19,
+        "id": 9044470,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4590704,
+            52.5144901
+          ],
+          [
+            13.458825,
+            52.5145838
+          ]
+        ]
+      },
+      "id": "link-9044470"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 138,
+        "startId": 140,
+        "frc": 6,
+        "length": 12,
+        "id": 9044471,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4592303,
+            52.5144292
+          ],
+          [
+            13.4590704,
+            52.5144901
+          ]
+        ]
+      },
+      "id": "link-9044471"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 140,
+        "startId": 75,
+        "frc": 6,
+        "length": 14,
+        "id": 9044472,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.459407,
+            52.5143601
+          ],
+          [
+            13.4592303,
+            52.5144292
+          ]
+        ]
+      },
+      "id": "link-9044472"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 141,
+        "startId": 52,
+        "frc": 6,
+        "length": 214,
+        "id": 9227878,
+        "direction": 2,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4689136,
+            52.5174726
+          ],
+          [
+            13.4690516,
+            52.517448
+          ],
+          [
+            13.4696,
+            52.5173502
+          ],
+          [
+            13.4703236,
+            52.5172211
+          ],
+          [
+            13.4709964,
+            52.5171011
+          ],
+          [
+            13.471448,
+            52.5170205
+          ],
+          [
+            13.4718236,
+            52.5169535
+          ],
+          [
+            13.4719541,
+            52.5169302
+          ]
+        ]
+      },
+      "id": "link-9227878"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 47,
+        "startId": 142,
+        "frc": 6,
+        "length": 120,
+        "id": 9497544,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4669131,
+            52.5201686
+          ],
+          [
+            13.4664359,
+            52.5191265
+          ]
+        ]
+      },
+      "id": "link-9497544"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 26,
+        "startId": 47,
+        "frc": 6,
+        "length": 97,
+        "id": 9497545,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664359,
+            52.5191265
+          ],
+          [
+            13.4660337,
+            52.5182804
+          ]
+        ]
+      },
+      "id": "link-9497545"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 42,
+        "startId": 26,
+        "frc": 6,
+        "length": 12,
+        "id": 9497546,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4660337,
+            52.5182804
+          ],
+          [
+            13.4659771,
+            52.5181688
+          ]
+        ]
+      },
+      "id": "link-9497546"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 70,
+        "startId": 56,
+        "frc": 6,
+        "length": 110,
+        "id": 9497547,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4686563,
+            52.5167401
+          ],
+          [
+            13.4685868,
+            52.5167159
+          ],
+          [
+            13.4684725,
+            52.5166728
+          ],
+          [
+            13.4681029,
+            52.5158439
+          ]
+        ]
+      },
+      "id": "link-9497547"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 27,
+        "startId": 70,
+        "frc": 6,
+        "length": 153,
+        "id": 9497548,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4681029,
+            52.5158439
+          ],
+          [
+            13.4678163,
+            52.5152185
+          ],
+          [
+            13.4675522,
+            52.5146453
+          ],
+          [
+            13.4675289,
+            52.5145941
+          ],
+          [
+            13.4675,
+            52.514512
+          ]
+        ]
+      },
+      "id": "link-9497548"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 16,
+        "startId": 41,
+        "frc": 6,
+        "length": 10,
+        "id": 9497775,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4659039,
+            52.5180116
+          ],
+          [
+            13.4658638,
+            52.5179215
+          ]
+        ]
+      },
+      "id": "link-9497775"
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "endId": 143,
+        "startId": 69,
+        "frc": 6,
+        "length": 7,
+        "id": 9534577,
+        "direction": 1,
+        "fow": 3
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [
+            13.4664717,
+            52.5161278
+          ],
+          [
+            13.4664356,
+            52.5160603
+          ]
+        ]
+      },
+      "id": "link-9534577"
+    }
+  ]
+}

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -1,0 +1,1 @@
+mod graph;

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -13,6 +13,7 @@ fn decode_line_location_reference_001() {
 
     let config = DecoderConfig {
         max_node_distance: Length::from_meters(10.0),
+        ..Default::default()
     };
 
     let _ = decode_base64_openlr(&config, graph, "CwmShiVYczPJBgCs/y0zAQ==");
@@ -24,6 +25,7 @@ fn find_candidate_nodes_001() {
 
     let config = DecoderConfig {
         max_node_distance: Length::from_meters(10.0),
+        ..Default::default()
     };
 
     let points = [
@@ -70,6 +72,7 @@ fn find_candidate_nodes_002() {
 
     let config = DecoderConfig {
         max_node_distance: Length::from_meters(100.0),
+        ..Default::default()
     };
 
     let points = [Point {

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -1,9 +1,10 @@
 mod graph;
 
 use openlr::{
-    Bearing, CandidateLine, CandidateLines, CandidateNode, CandidateNodes, Coordinate,
-    DecoderConfig, Fow, Frc, Length, LineAttributes, PathAttributes, Point, RatingScore, Route,
-    decode_base64_openlr, find_candidate_lines, find_candidate_nodes, resolve_routes,
+    Bearing, CandidateLine, CandidateLinePair, CandidateLines, CandidateNode, CandidateNodes,
+    Coordinate, DecoderConfig, Fow, Frc, Length, LineAttributes, PathAttributes, Point,
+    RatingScore, Route, decode_base64_openlr, find_candidate_lines, find_candidate_nodes,
+    resolve_routes,
 };
 use test_log::test;
 
@@ -102,6 +103,98 @@ fn find_candidate_nodes_002() {
 }
 
 #[test]
+fn find_candidate_nodes_003() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(5.0),
+        ..Default::default()
+    };
+
+    let lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, [lrp].iter()).collect();
+    assert_eq!(nodes, [CandidateNodes { lrp, nodes: vec![] }]);
+}
+
+#[test]
+fn find_candidate_nodes_004() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(100.0),
+        ..Default::default()
+    };
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(287),
+        },
+        path: None,
+    };
+
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, [first_lrp, last_lrp].iter())
+        .map(|candidate| {
+            candidate
+                .nodes
+                .into_iter()
+                .map(|node| node.vertex)
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert_eq!(
+        nodes,
+        [
+            vec![VertexId(68), VertexId(93), VertexId(92)],
+            vec![
+                VertexId(95),
+                VertexId(93),
+                VertexId(92),
+                VertexId(19),
+                VertexId(68)
+            ]
+        ]
+    );
+}
+
+#[test]
 fn find_candidate_lines_001() {
     let graph: &NetworkGraph = &NETWORK_GRAPH;
 
@@ -182,6 +275,91 @@ fn find_candidate_lines_001() {
 }
 
 #[test]
+fn find_candidate_lines_002() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(100.0),
+        max_bearing_difference: Bearing::from_degrees(90),
+        min_line_rating: RatingScore::from(800.0),
+        ..Default::default()
+    };
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(287),
+        },
+        path: None,
+    };
+
+    let points = [
+        CandidateNodes {
+            lrp: first_lrp,
+            nodes: vec![CandidateNode {
+                vertex: VertexId(68),
+                distance_to_lrp: Length::from_meters(30.0),
+            }],
+        },
+        CandidateNodes {
+            lrp: last_lrp,
+            nodes: vec![CandidateNode {
+                vertex: VertexId(68),
+                distance_to_lrp: Length::from_meters(100.0),
+            }],
+        },
+    ];
+
+    let lines = find_candidate_lines(&config, graph, points.into_iter()).unwrap();
+
+    let lines: Vec<_> = lines
+        .into_iter()
+        .map(|candidate| {
+            candidate
+                .lines
+                .into_iter()
+                .map(|line| {
+                    assert!(line.rating >= config.min_line_rating);
+                    (line.edge, line.distance_to_projection.map(|d| d.round()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert_eq!(
+        lines,
+        [
+            vec![(EdgeId(8717174), Some(Length::from_meters(29.0)))],
+            vec![
+                (EdgeId(8717174), Some(Length::from_meters(99.0))),
+                (EdgeId(4925291), None)
+            ]
+        ]
+    );
+}
+
+#[test]
 fn resolve_routes_001() {
     let graph: &NetworkGraph = &NETWORK_GRAPH;
 
@@ -221,32 +399,35 @@ fn resolve_routes_001() {
         path: None,
     };
 
+    let line1_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(926.3),
+        distance_to_projection: None,
+    };
+
+    let line2_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(4925291),
+        rating: RatingScore::from(880.4),
+        distance_to_projection: Some(Length::from_meters(141.6)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(924.9),
+        distance_to_projection: None,
+    };
+
     let candidate_lines = [
         CandidateLines {
             lrp: first_lrp,
-            lines: vec![
-                CandidateLine {
-                    lrp: first_lrp,
-                    edge: EdgeId(8717174),
-                    rating: RatingScore::from(926.3),
-                    distance_to_projection: None,
-                },
-                CandidateLine {
-                    lrp: first_lrp,
-                    edge: EdgeId(4925291),
-                    rating: RatingScore::from(880.4),
-                    distance_to_projection: Some(Length::from_meters(141.6)),
-                },
-            ],
+            lines: vec![line1_first_lrp, line2_first_lrp],
         },
         CandidateLines {
             lrp: last_lrp,
-            lines: vec![CandidateLine {
-                lrp: last_lrp,
-                edge: EdgeId(109783),
-                rating: RatingScore::from(924.9),
-                distance_to_projection: None,
-            }],
+            lines: vec![line_last_lrp],
         },
     ];
 
@@ -255,9 +436,202 @@ fn resolve_routes_001() {
     assert_eq!(
         routes,
         [Route {
-            lrp: first_lrp,
-            length: Length::from_meters(379.0),
-            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)]
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+            candidates: CandidateLinePair {
+                line_lrp1: line1_first_lrp,
+                line_lrp2: line_last_lrp
+            }
         }]
+    );
+}
+
+#[test]
+fn resolve_routes_002() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig::default();
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(287),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1128.7),
+        distance_to_projection: Some(Length::from_meters(29.0)),
+    };
+
+    let line1_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1122.7),
+        distance_to_projection: Some(Length::from_meters(99.0)),
+    };
+
+    let line2_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(4925291),
+        rating: RatingScore::from(900.0),
+        distance_to_projection: None,
+    };
+
+    let candidate_lines = [
+        CandidateLines {
+            lrp: first_lrp,
+            lines: vec![line_first_lrp],
+        },
+        CandidateLines {
+            lrp: last_lrp,
+            lines: vec![line1_last_lrp, line2_last_lrp],
+        },
+    ];
+
+    let routes = resolve_routes(&config, graph, &candidate_lines).unwrap();
+
+    assert_eq!(
+        routes,
+        [Route {
+            edges: vec![EdgeId(8717174)],
+            candidates: CandidateLinePair {
+                line_lrp1: line_first_lrp,
+                line_lrp2: line1_last_lrp
+            }
+        }]
+    );
+}
+
+#[test]
+fn resolve_routes_003() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig::default();
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(280.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(17),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1128.7),
+        distance_to_projection: Some(Length::from_meters(29.0)),
+    };
+
+    let line_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1122.7),
+        distance_to_projection: Some(Length::from_meters(99.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(924.9),
+        distance_to_projection: None,
+    };
+
+    let candidate_lines = [
+        CandidateLines {
+            lrp: first_lrp,
+            lines: vec![line_first_lrp],
+        },
+        CandidateLines {
+            lrp: second_lrp,
+            lines: vec![line_second_lrp],
+        },
+        CandidateLines {
+            lrp: last_lrp,
+            lines: vec![line_last_lrp],
+        },
+    ];
+
+    let routes = resolve_routes(&config, graph, &candidate_lines).unwrap();
+
+    assert_eq!(
+        routes,
+        [
+            Route {
+                edges: vec![], // first and second LRPs are on the same line
+                candidates: CandidateLinePair {
+                    line_lrp1: line_first_lrp,
+                    line_lrp2: line_second_lrp
+                }
+            },
+            Route {
+                edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+                candidates: CandidateLinePair {
+                    line_lrp1: line_second_lrp,
+                    line_lrp2: line_last_lrp
+                }
+            }
+        ]
     );
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -1,1 +1,12 @@
 mod graph;
+
+use openlr::decode_base64_openlr;
+
+use crate::graph::{NETWORK_GRAPH, NetworkGraph};
+
+#[test]
+fn decode_line_location_reference_001() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let _ = decode_base64_openlr(graph, "CwmShiVYczPJBgCs/y0zAQ==");
+}

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -2,8 +2,8 @@ mod graph;
 
 use openlr::{
     Bearing, CandidateLine, CandidateLinePair, CandidateLines, CandidateNode, CandidateNodes,
-    Coordinate, DecoderConfig, Fow, Frc, Length, LineAttributes, PathAttributes, Point,
-    RatingScore, Route, decode_base64_openlr, find_candidate_lines, find_candidate_nodes,
+    Coordinate, DecoderConfig, Fow, Frc, Length, LineAttributes, Offsets, PathAttributes, Point,
+    RatingScore, Route, Routes, decode_base64_openlr, find_candidate_lines, find_candidate_nodes,
     resolve_routes,
 };
 use test_log::test;
@@ -547,13 +547,14 @@ fn resolve_routes_001() {
 
     assert_eq!(
         routes,
-        [Route {
+        Routes::from(vec![Route {
             edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+            length: Length::from_meters(379.0),
             candidates: CandidateLinePair {
                 line_lrp1: line1_first_lrp,
                 line_lrp2: line_last_lrp
             }
-        }]
+        }])
     );
 }
 
@@ -628,13 +629,14 @@ fn resolve_routes_002() {
 
     assert_eq!(
         routes,
-        [Route {
+        Routes::from(vec![Route {
             edges: vec![EdgeId(8717174)],
+            length: Length::from_meters(136.0),
             candidates: CandidateLinePair {
                 line_lrp1: line_first_lrp,
                 line_lrp2: line1_last_lrp
             }
-        }]
+        }])
     );
 }
 
@@ -729,9 +731,10 @@ fn resolve_routes_003() {
 
     assert_eq!(
         routes,
-        [
+        Routes::from(vec![
             Route {
                 edges: vec![], // first and second LRPs are on the same line
+                length: Length::ZERO,
                 candidates: CandidateLinePair {
                     line_lrp1: line_first_lrp,
                     line_lrp2: line_second_lrp
@@ -739,12 +742,13 @@ fn resolve_routes_003() {
             },
             Route {
                 edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+                length: Length::from_meters(379.0),
                 candidates: CandidateLinePair {
                     line_lrp1: line_second_lrp,
                     line_lrp2: line_last_lrp
                 }
             }
-        ]
+        ])
     );
 }
 
@@ -853,9 +857,10 @@ fn resolve_routes_004() {
 
     assert_eq!(
         routes,
-        [
+        Routes::from(vec![
             Route {
                 edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+                length: Length::from_meters(379.0),
                 candidates: CandidateLinePair {
                     line_lrp1: line1_first_lrp,
                     line_lrp2: line1_second_lrp
@@ -863,11 +868,488 @@ fn resolve_routes_004() {
             },
             Route {
                 edges: vec![EdgeId(6770340), EdgeId(7531947)],
+                length: Length::from_meters(53.0),
                 candidates: CandidateLinePair {
                     line_lrp1: line1_second_lrp,
                     line_lrp2: line_last_lrp
                 }
             },
-        ]
+        ])
     );
+}
+
+#[test]
+fn calculate_offsets_001() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(17),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(926.3),
+        distance_to_projection: None,
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(924.9),
+        distance_to_projection: None,
+    };
+
+    let routes = Routes::from(vec![Route {
+        edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+        length: Length::from_meters(379.0),
+        candidates: CandidateLinePair {
+            line_lrp1: line_first_lrp,
+            line_lrp2: line_last_lrp,
+        },
+    }]);
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::ZERO);
+    assert_eq!(offset_end, Length::ZERO);
+}
+
+#[test]
+fn calculate_offsets_002() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(17),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(926.3),
+        distance_to_projection: Some(Length::from_meters(10.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(924.9),
+        distance_to_projection: Some(Length::from_meters(92.0)),
+    };
+
+    let routes: Routes<_> = vec![Route {
+        edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+        length: Length::from_meters(379.0),
+        candidates: CandidateLinePair {
+            line_lrp1: line_first_lrp,
+            line_lrp2: line_last_lrp,
+        },
+    }]
+    .into();
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::from_meters(10.0));
+    assert_eq!(offset_end, Length::from_meters(100.0));
+}
+
+#[test]
+fn calculate_offsets_003() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(287),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1128.7),
+        distance_to_projection: Some(Length::from_meters(20.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1122.7),
+        distance_to_projection: Some(Length::from_meters(36.0)),
+    };
+
+    let routes: Routes<_> = vec![Route {
+        edges: vec![EdgeId(8717174)],
+        length: Length::from_meters(136.0),
+        candidates: CandidateLinePair {
+            line_lrp1: line_first_lrp,
+            line_lrp2: line_last_lrp,
+        },
+    }]
+    .into();
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::from_meters(20.0));
+    assert_eq!(offset_end, Length::from_meters(100.0));
+}
+
+#[test]
+fn calculate_offsets_004() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4615506,
+            lat: 52.5170544,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(70.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4625506,
+            lat: 52.5168944,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(280.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(17),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1128.7),
+        distance_to_projection: Some(Length::from_meters(20.0)),
+    };
+
+    let line_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1122.7),
+        distance_to_projection: Some(Length::from_meters(36.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(924.9),
+        distance_to_projection: None,
+    };
+
+    let routes: Routes<_> = vec![
+        Route {
+            edges: vec![], // first and second LRPs are on the same line
+            length: Length::ZERO,
+            candidates: CandidateLinePair {
+                line_lrp1: line_first_lrp,
+                line_lrp2: line_second_lrp,
+            },
+        },
+        Route {
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+            length: Length::from_meters(379.0),
+            candidates: CandidateLinePair {
+                line_lrp1: line_second_lrp,
+                line_lrp2: line_last_lrp,
+            },
+        },
+    ]
+    .into();
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::from_meters(20.0));
+    assert_eq!(offset_end, Length::ZERO);
+}
+
+#[test]
+fn calculate_offsets_005() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(197),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(45.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4632200,
+            lat: 52.5147507,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc2,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(280),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1194.8),
+        distance_to_projection: None,
+    };
+
+    let line_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(6770340),
+        rating: RatingScore::from(1193.5),
+        distance_to_projection: None,
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(7531947),
+        rating: RatingScore::from(1176.0),
+        distance_to_projection: None,
+    };
+
+    let routes: Routes<_> = vec![
+        Route {
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+            length: Length::from_meters(379.0),
+            candidates: CandidateLinePair {
+                line_lrp1: line_first_lrp,
+                line_lrp2: line_second_lrp,
+            },
+        },
+        Route {
+            edges: vec![EdgeId(6770340), EdgeId(7531947)],
+            length: Length::from_meters(53.0),
+            candidates: CandidateLinePair {
+                line_lrp1: line_second_lrp,
+                line_lrp2: line_last_lrp,
+            },
+        },
+    ]
+    .into();
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::ZERO);
+    assert_eq!(offset_end, Length::ZERO);
+}
+
+#[test]
+fn calculate_offsets_006() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(197),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(45.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4632200,
+            lat: 52.5147507,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc2,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(280),
+        },
+        path: None,
+    };
+
+    let line_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1194.8),
+        distance_to_projection: Some(Length::from_meters(10.0)),
+    };
+
+    let line_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(6770340),
+        rating: RatingScore::from(1193.5),
+        distance_to_projection: Some(Length::from_meters(5.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(7531947),
+        rating: RatingScore::from(1176.0),
+        distance_to_projection: Some(Length::from_meters(27.0)),
+    };
+
+    let routes: Routes<_> = vec![
+        Route {
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+            length: Length::from_meters(379.0),
+            candidates: CandidateLinePair {
+                line_lrp1: line_first_lrp,
+                line_lrp2: line_second_lrp,
+            },
+        },
+        Route {
+            edges: vec![EdgeId(6770340), EdgeId(7531947)],
+            length: Length::from_meters(53.0),
+            candidates: CandidateLinePair {
+                line_lrp1: line_second_lrp,
+                line_lrp2: line_last_lrp,
+            },
+        },
+    ]
+    .into();
+
+    let (offset_start, offset_end) = routes.calculate_offsets(graph, Offsets::default()).unwrap();
+
+    assert_eq!(offset_start, Length::from_meters(10.0));
+    assert_eq!(offset_end, Length::from_meters(10.0));
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -466,7 +466,7 @@ fn find_candidate_lines_003() {
                 (EdgeId(6770340), None),
                 (EdgeId(109783), Some(Length::from_meters(191.0)))
             ],
-            vec![(EdgeId(7531947), None),]
+            vec![(EdgeId(7531947), None)]
         ]
     );
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -360,6 +360,118 @@ fn find_candidate_lines_002() {
 }
 
 #[test]
+fn find_candidate_lines_003() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(100.0),
+        max_bearing_difference: Bearing::from_degrees(90),
+        min_line_rating: RatingScore::from(800.0),
+        ..Default::default()
+    };
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(197),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(45.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4632200,
+            lat: 52.5147507,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc2,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(280),
+        },
+        path: None,
+    };
+
+    let points = [
+        CandidateNodes {
+            lrp: first_lrp,
+            nodes: vec![CandidateNode {
+                vertex: VertexId(68),
+                distance_to_lrp: Length::from_meters(1.74),
+            }],
+        },
+        CandidateNodes {
+            lrp: second_lrp,
+            nodes: vec![CandidateNode {
+                vertex: VertexId(20),
+                distance_to_lrp: Length::from_meters(2.16),
+            }],
+        },
+        CandidateNodes {
+            lrp: last_lrp,
+            nodes: vec![CandidateNode {
+                vertex: VertexId(7),
+                distance_to_lrp: Length::from_meters(8.0),
+            }],
+        },
+    ];
+
+    let lines = find_candidate_lines(&config, graph, points.into_iter()).unwrap();
+
+    let lines: Vec<_> = lines
+        .into_iter()
+        .map(|candidate| {
+            candidate
+                .lines
+                .into_iter()
+                .map(|line| {
+                    assert!(line.rating >= config.min_line_rating);
+                    (line.edge, line.distance_to_projection.map(|d| d.round()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert_eq!(
+        lines,
+        [
+            vec![
+                (EdgeId(8717174), None),
+                (EdgeId(4925291), Some(Length::from_meters(142.0))) // projected line
+            ],
+            vec![
+                (EdgeId(6770340), None),
+                (EdgeId(109783), Some(Length::from_meters(191.0)))
+            ],
+            vec![(EdgeId(7531947), None),]
+        ]
+    );
+}
+
+#[test]
 fn resolve_routes_001() {
     let graph: &NetworkGraph = &NETWORK_GRAPH;
 
@@ -632,6 +744,130 @@ fn resolve_routes_003() {
                     line_lrp2: line_last_lrp
                 }
             }
+        ]
+    );
+}
+
+#[test]
+fn resolve_routes_004() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig::default();
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let second_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(197),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(45.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.4632200,
+            lat: 52.5147507,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc2,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(280),
+        },
+        path: None,
+    };
+
+    let line1_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(8717174),
+        rating: RatingScore::from(1194.8),
+        distance_to_projection: None,
+    };
+
+    let line2_first_lrp = CandidateLine {
+        lrp: first_lrp,
+        edge: EdgeId(4925291),
+        rating: RatingScore::from(1135.3),
+        distance_to_projection: Some(Length::from_meters(142.0)),
+    };
+
+    let line1_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(6770340),
+        rating: RatingScore::from(1193.5),
+        distance_to_projection: None,
+    };
+
+    let line2_second_lrp = CandidateLine {
+        lrp: second_lrp,
+        edge: EdgeId(109783),
+        rating: RatingScore::from(1137.7),
+        distance_to_projection: Some(Length::from_meters(191.0)),
+    };
+
+    let line_last_lrp = CandidateLine {
+        lrp: last_lrp,
+        edge: EdgeId(7531947),
+        rating: RatingScore::from(1176.0),
+        distance_to_projection: None,
+    };
+
+    let candidate_lines = [
+        CandidateLines {
+            lrp: first_lrp,
+            lines: vec![line1_first_lrp, line2_first_lrp],
+        },
+        CandidateLines {
+            lrp: second_lrp,
+            lines: vec![line1_second_lrp, line2_second_lrp],
+        },
+        CandidateLines {
+            lrp: last_lrp,
+            lines: vec![line_last_lrp],
+        },
+    ];
+
+    let routes = resolve_routes(&config, graph, &candidate_lines).unwrap();
+
+    assert_eq!(
+        routes,
+        [
+            Route {
+                edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+                candidates: CandidateLinePair {
+                    line_lrp1: line1_first_lrp,
+                    line_lrp2: line1_second_lrp
+                }
+            },
+            Route {
+                edges: vec![EdgeId(6770340), EdgeId(7531947)],
+                candidates: CandidateLinePair {
+                    line_lrp1: line1_second_lrp,
+                    line_lrp2: line_last_lrp
+                }
+            },
         ]
     );
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -163,11 +163,20 @@ fn find_candidate_lines_001() {
                 .into_iter()
                 .map(|line| {
                     assert!(line.rating >= config.min_line_rating);
-                    (line.edge, line.distance_to_projection)
+                    (line.edge, line.distance_to_projection.map(|d| d.round()))
                 })
                 .collect::<Vec<_>>()
         })
         .collect();
 
-    assert_eq!(lines, [[(EdgeId(8717174), None)], [(EdgeId(109783), None)]]);
+    assert_eq!(
+        lines,
+        [
+            vec![
+                (EdgeId(8717174), None),
+                (EdgeId(4925291), Some(Length::from_meters(142.0))) // projected line
+            ],
+            vec![(EdgeId(109783), None)]
+        ]
+    );
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -61,7 +61,7 @@ fn find_candidate_nodes_001() {
         },
     ];
 
-    let nodes: Vec<_> = find_candidate_nodes(&config, graph, points.iter())
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, &points)
         .flat_map(|candidate| candidate.nodes)
         .map(|node| (node.vertex, (node.distance_to_lrp.meters() * 100.0).round()))
         .collect();
@@ -87,7 +87,7 @@ fn find_candidate_nodes_002() {
         path: None,
     }];
 
-    let nodes: Vec<_> = find_candidate_nodes(&config, graph, points.iter())
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, &points)
         .flat_map(|candidate| candidate.nodes)
         .map(|node| (node.vertex, node.distance_to_lrp.meters().round()))
         .collect();
@@ -127,7 +127,7 @@ fn find_candidate_nodes_003() {
         }),
     };
 
-    let nodes: Vec<_> = find_candidate_nodes(&config, graph, [lrp].iter()).collect();
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, &[lrp]).collect();
     assert_eq!(nodes, [CandidateNodes { lrp, nodes: vec![] }]);
 }
 
@@ -247,7 +247,7 @@ fn find_candidate_lines_001() {
         },
     ];
 
-    let lines: Vec<_> = find_candidate_lines(&config, graph, points.into_iter())
+    let lines: Vec<_> = find_candidate_lines(&config, graph, points)
         .unwrap()
         .into_iter()
         .map(|candidate| {
@@ -331,7 +331,7 @@ fn find_candidate_lines_002() {
         },
     ];
 
-    let lines = find_candidate_lines(&config, graph, points.into_iter()).unwrap();
+    let lines = find_candidate_lines(&config, graph, points).unwrap();
 
     let lines: Vec<_> = lines
         .into_iter()
@@ -439,7 +439,7 @@ fn find_candidate_lines_003() {
         },
     ];
 
-    let lines = find_candidate_lines(&config, graph, points.into_iter()).unwrap();
+    let lines = find_candidate_lines(&config, graph, points).unwrap();
 
     let lines: Vec<_> = lines
         .into_iter()

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -1,12 +1,97 @@
 mod graph;
 
-use openlr::decode_base64_openlr;
+use openlr::{
+    Bearing, Coordinate, DecoderConfig, Fow, Frc, Length, LineAttributes, PathAttributes, Point,
+    decode_base64_openlr, find_candidate_nodes,
+};
 
-use crate::graph::{NETWORK_GRAPH, NetworkGraph};
+use crate::graph::{NETWORK_GRAPH, NetworkGraph, VertexId};
 
 #[test]
 fn decode_line_location_reference_001() {
     let graph: &NetworkGraph = &NETWORK_GRAPH;
 
-    let _ = decode_base64_openlr(graph, "CwmShiVYczPJBgCs/y0zAQ==");
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(10.0),
+    };
+
+    let _ = decode_base64_openlr(&config, graph, "CwmShiVYczPJBgCs/y0zAQ==");
+}
+
+#[test]
+fn find_candidate_nodes_001() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(10.0),
+    };
+
+    let points = [
+        Point {
+            coordinate: Coordinate {
+                lon: 13.46112,
+                lat: 52.51711,
+            },
+            line: LineAttributes {
+                frc: Frc::Frc6,
+                fow: Fow::SingleCarriageway,
+                bearing: Bearing::from_degrees(107),
+            },
+            path: Some(PathAttributes {
+                lfrcnp: Frc::Frc6,
+                dnp: Length::from_meters(381.0),
+            }),
+        },
+        Point {
+            coordinate: Coordinate {
+                lon: 13.46284,
+                lat: 52.51500,
+            },
+            line: LineAttributes {
+                frc: Frc::Frc6,
+                fow: Fow::SingleCarriageway,
+                bearing: Bearing::from_degrees(17),
+            },
+            path: None,
+        },
+    ];
+
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, &points)
+        .flat_map(|candidate| candidate.nodes)
+        .map(|node| (node.vertex, (node.distance_to_lrp.meters() * 100.0).round()))
+        .collect();
+
+    assert_eq!(nodes, [(VertexId(68), 174.0), (VertexId(20), 216.0)]);
+}
+
+#[test]
+fn find_candidate_nodes_002() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(100.0),
+    };
+
+    let points = [Point {
+        coordinate: Coordinate {
+            lon: 13.454789,
+            lat: 52.5157088,
+        },
+        line: LineAttributes::default(),
+        path: None,
+    }];
+
+    let nodes: Vec<_> = find_candidate_nodes(&config, graph, &points)
+        .flat_map(|candidate| candidate.nodes)
+        .map(|node| (node.vertex, node.distance_to_lrp.meters().round()))
+        .collect();
+
+    assert_eq!(
+        nodes,
+        [
+            (VertexId(37), 37.0),
+            (VertexId(1), 39.0),
+            (VertexId(105), 55.0)
+        ]
+    );
 }

--- a/tests/decoder.rs
+++ b/tests/decoder.rs
@@ -1,9 +1,9 @@
 mod graph;
 
 use openlr::{
-    Bearing, CandidateNode, CandidateNodes, Coordinate, DecoderConfig, Fow, Frc, Length,
-    LineAttributes, PathAttributes, Point, RatingScore, decode_base64_openlr, find_candidate_lines,
-    find_candidate_nodes,
+    Bearing, CandidateLine, CandidateLines, CandidateNode, CandidateNodes, Coordinate,
+    DecoderConfig, Fow, Frc, Length, LineAttributes, PathAttributes, Point, RatingScore, Route,
+    decode_base64_openlr, find_candidate_lines, find_candidate_nodes, resolve_routes,
 };
 use test_log::test;
 
@@ -178,5 +178,86 @@ fn find_candidate_lines_001() {
             ],
             vec![(EdgeId(109783), None)]
         ]
+    );
+}
+
+#[test]
+fn resolve_routes_001() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    let config = DecoderConfig {
+        max_node_distance: Length::from_meters(100.0),
+        max_bearing_difference: Bearing::from_degrees(90),
+        min_line_rating: RatingScore::from(800.0),
+        ..Default::default()
+    };
+
+    let first_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46112,
+            lat: 52.51711,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(107),
+        },
+        path: Some(PathAttributes {
+            lfrcnp: Frc::Frc6,
+            dnp: Length::from_meters(381.0),
+        }),
+    };
+
+    let last_lrp = Point {
+        coordinate: Coordinate {
+            lon: 13.46284,
+            lat: 52.51500,
+        },
+        line: LineAttributes {
+            frc: Frc::Frc6,
+            fow: Fow::SingleCarriageway,
+            bearing: Bearing::from_degrees(17),
+        },
+        path: None,
+    };
+
+    let candidate_lines = [
+        CandidateLines {
+            lrp: first_lrp,
+            lines: vec![
+                CandidateLine {
+                    lrp: first_lrp,
+                    edge: EdgeId(8717174),
+                    rating: RatingScore::from(926.3),
+                    distance_to_projection: None,
+                },
+                CandidateLine {
+                    lrp: first_lrp,
+                    edge: EdgeId(4925291),
+                    rating: RatingScore::from(880.4),
+                    distance_to_projection: Some(Length::from_meters(141.6)),
+                },
+            ],
+        },
+        CandidateLines {
+            lrp: last_lrp,
+            lines: vec![CandidateLine {
+                lrp: last_lrp,
+                edge: EdgeId(109783),
+                rating: RatingScore::from(924.9),
+                distance_to_projection: None,
+            }],
+        },
+    ];
+
+    let routes = resolve_routes(&config, graph, &candidate_lines).unwrap();
+
+    assert_eq!(
+        routes,
+        [Route {
+            lrp: first_lrp,
+            length: Length::from_meters(379.0),
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)]
+        }]
     );
 }

--- a/tests/graph/geojson.rs
+++ b/tests/graph/geojson.rs
@@ -1,0 +1,186 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use geojson::{Feature, FeatureCollection, Value};
+use openlr::{Coordinate, Fow, Frc, Length};
+
+static GEOJSON_GRAPH: LazyLock<GeojsonGraph> = LazyLock::new(|| {
+    let geojson = include_str!("../data/graph.geojson");
+    GeojsonGraph::parse_geojson(geojson)
+});
+
+type NodeId = i64;
+
+/// Identify a directed line (negative value represent a reversed edge).
+type LineId = i64;
+
+#[derive(Debug, Default)]
+struct GeojsonGraph {
+    nodes: HashMap<NodeId, Node>,
+    lines: HashMap<LineId, Line>,
+}
+
+#[derive(Debug)]
+struct Node {
+    id: NodeId,
+    location: Coordinate,
+    outgoing_lines: Vec<(LineId, NodeId)>,
+}
+
+#[derive(Debug)]
+struct Line {
+    id: LineId,
+    start_id: NodeId,
+    end_id: NodeId,
+    length: Length,
+    fow: Fow,
+    frc: Frc,
+    geometry: Vec<Coordinate>,
+}
+
+impl GeojsonGraph {
+    fn parse_geojson(geojson: &str) -> Self {
+        let FeatureCollection { features, .. } = geojson.parse().unwrap();
+
+        let mut graph = GeojsonGraph::default();
+
+        for Feature {
+            geometry,
+            properties,
+            ..
+        } in &features
+        {
+            let geometry = geometry.as_ref().unwrap();
+            let properties = properties.as_ref().unwrap();
+
+            if let Value::Point(point) = &geometry.value {
+                let id = properties.get("id").unwrap().as_i64().unwrap();
+
+                let location = Coordinate {
+                    lon: point[0],
+                    lat: point[1],
+                };
+
+                graph.nodes.insert(
+                    id,
+                    Node {
+                        id,
+                        location,
+                        outgoing_lines: vec![],
+                    },
+                );
+            }
+        }
+
+        for Feature {
+            geometry,
+            properties,
+            ..
+        } in features
+        {
+            let geometry = geometry.as_ref().unwrap();
+            let properties = properties.as_ref().unwrap();
+
+            if let Value::LineString(line) = &geometry.value {
+                let id = properties.get("id").unwrap().as_i64().unwrap();
+                let mut start_id = properties.get("startId").unwrap().as_i64().unwrap();
+                let mut end_id = properties.get("endId").unwrap().as_i64().unwrap();
+                let length = properties.get("length").unwrap().as_i64().unwrap() as f64;
+                let frc = properties.get("frc").unwrap().as_i64().unwrap() as i8;
+                let fow = properties.get("fow").unwrap().as_i64().unwrap() as i8;
+                let direction = properties.get("direction").unwrap().as_i64().unwrap();
+
+                let mut geometry: Vec<Coordinate> = line
+                    .iter()
+                    .map(|line| Coordinate {
+                        lon: line[0],
+                        lat: line[1],
+                    })
+                    .collect();
+
+                if direction == 3 {
+                    // backward direction
+                    geometry.reverse();
+                    std::mem::swap(&mut start_id, &mut end_id);
+                }
+
+                let node = graph.nodes.get_mut(&start_id).unwrap();
+                node.outgoing_lines.push((id, end_id));
+
+                if direction == 1 && start_id != end_id {
+                    // both directions
+                    let node = graph.nodes.get_mut(&end_id).unwrap();
+                    node.outgoing_lines.push((-id, start_id));
+                }
+
+                graph.lines.insert(
+                    id,
+                    Line {
+                        id,
+                        start_id,
+                        end_id,
+                        length: Length::from_meters(length),
+                        frc: Frc::from_value(frc).unwrap(),
+                        fow: Fow::from_value(fow).unwrap(),
+                        geometry,
+                    },
+                );
+            }
+        }
+
+        graph
+    }
+}
+
+#[test]
+fn geojson_graph_line_attributes() {
+    let graph = &GEOJSON_GRAPH;
+
+    let line = graph.lines.get(&16218).unwrap();
+    assert_eq!(line.id, 16218);
+    assert_eq!(line.start_id, 1);
+    assert_eq!(line.end_id, 2);
+    assert_eq!(line.length, Length::from_meters(217.0));
+    assert_eq!(line.frc, Frc::Frc2);
+    assert_eq!(line.fow, Fow::SingleCarriageway);
+    assert_eq!(line.geometry.len(), 7);
+
+    let line = graph.lines.get(&8323959).unwrap();
+    assert_eq!(line.id, 8323959);
+    assert_eq!(line.start_id, 129);
+    assert_eq!(line.end_id, 126);
+    assert_eq!(line.length, Length::from_meters(11.0));
+    assert_eq!(line.frc, Frc::Frc6);
+    assert_eq!(line.fow, Fow::SingleCarriageway);
+    assert_eq!(line.geometry.len(), 2);
+}
+
+#[test]
+fn geojson_graph_node_attributes() {
+    let graph = &GEOJSON_GRAPH;
+
+    let node = graph.nodes.get(&1).unwrap();
+    assert_eq!(node.id, 1);
+    assert_eq!(node.location.lon, 13.454214);
+    assert_eq!(node.location.lat, 52.5157088);
+    assert_eq!(node.outgoing_lines, vec![(16218, 2)]);
+
+    let node = graph.nodes.get(&2).unwrap();
+    assert_eq!(node.id, 2);
+    assert_eq!(node.outgoing_lines, vec![(16219, 3), (-3622025, 58)]);
+
+    let node = graph.nodes.get(&29).unwrap();
+    assert_eq!(node.id, 29);
+    assert_eq!(
+        node.outgoing_lines,
+        vec![(580854, 30), (-2711304, 51), (2711305, 48)]
+    );
+
+    let node = graph.nodes.get(&126).unwrap();
+    assert_eq!(node.id, 126);
+    assert_eq!(node.outgoing_lines, vec![(8323953, 127), (-8323959, 129)]);
+
+    let node = graph.nodes.get(&134).unwrap(); // loop
+    assert_eq!(node.id, 134);
+    assert_eq!(node.outgoing_lines, vec![(8345025, 134), (8345026, 123)]);
+}

--- a/tests/graph/mod.rs
+++ b/tests/graph/mod.rs
@@ -2,4 +2,4 @@ mod geojson;
 mod network;
 
 pub use geojson::{GEOJSON_GRAPH, GeojsonGraph};
-pub use network::{NETWORK_GRAPH, NetworkGraph, VertexId};
+pub use network::{EdgeId, NETWORK_GRAPH, NetworkGraph, VertexId};

--- a/tests/graph/mod.rs
+++ b/tests/graph/mod.rs
@@ -1,1 +1,4 @@
 mod geojson;
+mod network;
+
+pub use geojson::{GEOJSON_GRAPH, GeojsonGraph};

--- a/tests/graph/mod.rs
+++ b/tests/graph/mod.rs
@@ -1,0 +1,1 @@
+mod geojson;

--- a/tests/graph/mod.rs
+++ b/tests/graph/mod.rs
@@ -2,3 +2,4 @@ mod geojson;
 mod network;
 
 pub use geojson::{GEOJSON_GRAPH, GeojsonGraph};
+pub use network::{NETWORK_GRAPH, NetworkGraph};

--- a/tests/graph/mod.rs
+++ b/tests/graph/mod.rs
@@ -2,4 +2,4 @@ mod geojson;
 mod network;
 
 pub use geojson::{GEOJSON_GRAPH, GeojsonGraph};
-pub use network::{NETWORK_GRAPH, NetworkGraph};
+pub use network::{NETWORK_GRAPH, NetworkGraph, VertexId};

--- a/tests/graph/network.rs
+++ b/tests/graph/network.rs
@@ -11,7 +11,7 @@ pub static NETWORK_GRAPH: LazyLock<NetworkGraph> =
     LazyLock::new(|| NetworkGraph::from_geojson_graph(&GEOJSON_GRAPH));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct VertexId(i64);
+pub struct VertexId(pub i64);
 
 impl VertexId {
     const fn index(&self) -> usize {
@@ -20,7 +20,7 @@ impl VertexId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct EdgeId(i64);
+pub struct EdgeId(pub i64);
 
 impl EdgeId {
     const fn is_reversed(&self) -> bool {

--- a/tests/graph/network.rs
+++ b/tests/graph/network.rs
@@ -464,6 +464,11 @@ fn network_graph_edge_bearing() {
         get_edge_bearing(EdgeId(-4925291)),
         Bearing::from_degrees(286)
     );
+
+    assert_eq!(
+        get_edge_bearing(EdgeId(7531947)),
+        Bearing::from_degrees(100)
+    );
 }
 
 #[test]

--- a/tests/graph/network.rs
+++ b/tests/graph/network.rs
@@ -1,0 +1,899 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use geo::{BoundingRect, Distance, HaversineClosestPoint, InterpolatableLine};
+use graph::prelude::{DirectedCsrGraph, DirectedNeighborsWithValues};
+use openlr::{Bearing, Coordinate, DirectedGraph, Fow, Frc, Length};
+
+use crate::graph::{GEOJSON_GRAPH, GeojsonGraph};
+
+pub static NETWORK_GRAPH: LazyLock<NetworkGraph> =
+    LazyLock::new(|| NetworkGraph::from_geojson_graph(&GEOJSON_GRAPH));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VertexId(i64);
+
+impl VertexId {
+    const fn index(&self) -> usize {
+        self.0 as usize
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EdgeId(i64);
+
+impl EdgeId {
+    const fn is_reversed(&self) -> bool {
+        self.0.is_negative()
+    }
+
+    const fn undirected(&self) -> Self {
+        Self(self.0.abs())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct EdgeProperties {
+    length: Length,
+    frc: Frc,
+    fow: Fow,
+    geometry: geo::LineString,
+    vertices: [VertexId; 2],
+}
+
+pub struct NetworkGraph {
+    network: DirectedCsrGraph<usize, (), EdgeId>,
+    geospatial_nodes: rstar::RTree<GeospatialNode>,
+    geospatial_edges: rstar::RTree<GeospatialEdge>,
+    edge_properties: HashMap<EdgeId, EdgeProperties>,
+}
+
+#[derive(Debug)]
+struct GeospatialNode {
+    vertex: VertexId,
+    location: Coordinate,
+}
+
+impl rstar::RTreeObject for GeospatialNode {
+    type Envelope = rstar::AABB<geo::Point>;
+    fn envelope(&self) -> Self::Envelope {
+        geo::Point::new(self.location.lon, self.location.lat).envelope()
+    }
+}
+
+impl rstar::PointDistance for GeospatialNode {
+    fn distance_2(&self, point: &geo::Point) -> f64 {
+        let location = geo::Point::new(self.location.lon, self.location.lat);
+        geo::Haversine.distance(location, *point).powf(2.0)
+    }
+}
+
+#[derive(Debug)]
+struct GeospatialEdge {
+    edge: EdgeId,
+    geometry: geo::LineString,
+}
+
+impl rstar::RTreeObject for GeospatialEdge {
+    type Envelope = rstar::AABB<geo::Point>;
+
+    fn envelope(&self) -> Self::Envelope {
+        let bbox = self.geometry.bounding_rect().unwrap();
+        rstar::AABB::from_corners(
+            geo::Point::new(bbox.min().x, bbox.min().y),
+            geo::Point::new(bbox.max().x, bbox.max().y),
+        )
+    }
+}
+
+impl rstar::PointDistance for GeospatialEdge {
+    fn distance_2(&self, point: &geo::Point) -> f64 {
+        match self.geometry.haversine_closest_point(point) {
+            geo::Closest::SinglePoint(p) | geo::Closest::Intersection(p) => {
+                geo::Haversine.distance(p, *point).powf(2.0)
+            }
+            geo::Closest::Indeterminate => f64::INFINITY,
+        }
+    }
+}
+
+impl DirectedGraph for NetworkGraph {
+    type EdgeId = EdgeId;
+    type VertexId = VertexId;
+
+    fn get_edge_start_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .map(|EdgeProperties { vertices, .. }| {
+                if edge.is_reversed() {
+                    vertices[1]
+                } else {
+                    vertices[0]
+                }
+            })
+    }
+
+    fn get_edge_end_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .map(|EdgeProperties { vertices, .. }| {
+                if edge.is_reversed() {
+                    vertices[0]
+                } else {
+                    vertices[1]
+                }
+            })
+    }
+
+    fn get_edge_length(&self, edge: Self::EdgeId) -> Option<Length> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .map(|EdgeProperties { length, .. }| *length)
+    }
+
+    fn get_edge_frc(&self, edge: Self::EdgeId) -> Option<Frc> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .map(|EdgeProperties { frc, .. }| *frc)
+    }
+
+    fn get_edge_fow(&self, edge: Self::EdgeId) -> Option<Fow> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .map(|EdgeProperties { fow, .. }| *fow)
+    }
+
+    fn get_edge_coordinates(&self, edge: Self::EdgeId) -> impl Iterator<Item = Coordinate> {
+        self.edge_properties
+            .get(&edge.undirected())
+            .into_iter()
+            .flat_map(move |EdgeProperties { geometry, .. }| {
+                let geometry = geometry.coords().map(|coordinate| Coordinate {
+                    lon: coordinate.x,
+                    lat: coordinate.y,
+                });
+
+                let geometry: Box<dyn Iterator<Item = Coordinate>> = if edge.is_reversed() {
+                    Box::new(geometry.into_iter().rev())
+                } else {
+                    Box::new(geometry.into_iter())
+                };
+
+                geometry
+            })
+    }
+
+    fn vertex_exiting_edges(
+        &self,
+        vertex: Self::VertexId,
+    ) -> impl Iterator<Item = (Self::EdgeId, Self::VertexId)> {
+        let mut edges: Vec<_> = self
+            .network
+            .out_neighbors_with_values(vertex.index())
+            .map(|item| (item.value, VertexId(item.target as i64)))
+            .collect();
+
+        edges.sort();
+        edges.into_iter()
+    }
+
+    fn vertex_entering_edges(
+        &self,
+        vertex: Self::VertexId,
+    ) -> impl Iterator<Item = (Self::EdgeId, Self::VertexId)> {
+        let mut edges: Vec<_> = self
+            .network
+            .in_neighbors_with_values(vertex.index())
+            .map(|item| (item.value, VertexId(item.target as i64)))
+            .collect();
+
+        edges.sort();
+        edges.into_iter()
+    }
+
+    fn nearest_vertices_within_distance(
+        &self,
+        coordinate: Coordinate,
+        max_distance: Length,
+    ) -> impl Iterator<Item = (Self::VertexId, Length)> {
+        let max_distance_2 = max_distance.meters() * max_distance.meters();
+        let point = geo::Point::new(coordinate.lon, coordinate.lat);
+
+        self.geospatial_nodes
+            .nearest_neighbor_iter_with_distance_2(&point)
+            .take_while(move |(_, distance_2)| *distance_2 <= max_distance_2)
+            .map(|(node, distance_2)| {
+                let length = Length::from_meters(distance_2.sqrt());
+                (node.vertex, length)
+            })
+    }
+
+    fn nearest_edges_within_distance(
+        &self,
+        coordinate: Coordinate,
+        max_distance: Length,
+    ) -> impl Iterator<Item = (Self::EdgeId, Length)> {
+        let max_distance_2 = max_distance.meters() * max_distance.meters();
+        let point = geo::Point::new(coordinate.lon, coordinate.lat);
+
+        self.geospatial_edges
+            .nearest_neighbor_iter_with_distance_2(&point)
+            .take_while(move |(_, distance_2)| *distance_2 <= max_distance_2)
+            .map(|(node, distance_2)| {
+                let length = Length::from_meters(distance_2.sqrt());
+                (node.edge, length)
+            })
+    }
+
+    fn get_distance_from_start_vertex(
+        &self,
+        edge: Self::EdgeId,
+        coordinate: Coordinate,
+    ) -> Option<Length> {
+        let mut closest_distance = f64::INFINITY;
+        let mut distance_from_start = 0.0;
+        let mut distance_acc = 0.0;
+
+        let point = geo::Point::new(coordinate.lon, coordinate.lat);
+
+        for line in self.edge_line_string(edge).lines() {
+            match line.haversine_closest_point(&point) {
+                geo::Closest::SinglePoint(p) | geo::Closest::Intersection(p) => {
+                    let distance_to_line = geo::Haversine.distance(point, p);
+
+                    if distance_to_line < closest_distance {
+                        // this is the closest line segment of the whole geometry (so far)
+                        closest_distance = distance_to_line;
+                        let distance = geo::Haversine.distance(line.start_point(), p);
+                        distance_from_start = distance_acc + distance;
+                    }
+
+                    use geo::Length;
+                    distance_acc += geo::Haversine.length(&line);
+                }
+                geo::Closest::Indeterminate => return None,
+            }
+        }
+
+        Some(Length::from_meters(distance_from_start))
+    }
+
+    fn get_edge_bearing_between(
+        &self,
+        edge: Self::EdgeId,
+        distance_start: Length,
+        offset: Length,
+    ) -> Option<Bearing> {
+        let edge_length = self.get_edge_length(edge)?;
+        if distance_start > edge_length {
+            return None;
+        }
+
+        let distance_end = (distance_start + offset).min(edge_length).max(Length::ZERO);
+
+        let ratio_p1 = distance_start.meters() / edge_length.meters();
+        let ratio_p2 = distance_end.meters() / edge_length.meters();
+
+        let geometry = self.edge_line_string(edge);
+        let p1 = geometry.point_at_ratio_from_start(&geo::Haversine, ratio_p1)?;
+        let p2 = geometry.point_at_ratio_from_start(&geo::Haversine, ratio_p2)?;
+
+        let degrees = {
+            use geo::Bearing;
+            geo::Haversine.bearing(p1, p2).round() as u16
+        };
+
+        Some(Bearing::from_degrees(degrees))
+    }
+}
+
+impl NetworkGraph {
+    fn edge_line_string(&self, edge: EdgeId) -> geo::LineString {
+        geo::LineString::from_iter(
+            self.get_edge_coordinates(edge)
+                .map(|coordinate| geo::coord! { x: coordinate.lon, y: coordinate.lat }),
+        )
+    }
+
+    fn from_geojson_graph(graph: &GeojsonGraph) -> NetworkGraph {
+        let edge_properties = graph
+            .lines
+            .iter()
+            .map(|(&line_id, line)| {
+                let property = EdgeProperties {
+                    length: line.length,
+                    frc: line.frc,
+                    fow: line.fow,
+                    geometry: line.geometry.clone(),
+                    vertices: [VertexId(line.start_id), VertexId(line.end_id)],
+                };
+
+                (EdgeId(line_id), property)
+            })
+            .collect();
+
+        let network_edges: Vec<(usize, usize, EdgeId)> = graph
+            .nodes
+            .iter()
+            .flat_map(|(&from_id, node)| {
+                let from_id: usize = from_id.try_into().unwrap();
+                node.outgoing_lines.iter().map(move |&(line_id, to_id)| {
+                    let to_id: usize = to_id.try_into().unwrap();
+                    (from_id, to_id, EdgeId(line_id))
+                })
+            })
+            .collect();
+
+        let geospatial_nodes: Vec<GeospatialNode> = graph
+            .nodes
+            .iter()
+            .map(|(&from_id, node)| GeospatialNode {
+                vertex: VertexId(from_id),
+                location: node.location,
+            })
+            .collect();
+
+        let directed_edges: HashSet<EdgeId> = graph
+            .nodes
+            .iter()
+            .flat_map(|(_, node)| {
+                node.outgoing_lines
+                    .iter()
+                    .map(|&(line_id, _)| EdgeId(line_id))
+            })
+            .collect();
+
+        let geospatial_edges: Vec<GeospatialEdge> = directed_edges
+            .into_iter()
+            .map(|edge_id| {
+                let line = graph.lines.get(&edge_id.undirected().0).unwrap();
+                GeospatialEdge {
+                    edge: edge_id,
+                    geometry: line.geometry.clone(),
+                }
+            })
+            .collect();
+
+        NetworkGraph {
+            network: graph::prelude::GraphBuilder::new()
+                .edges_with_values(network_edges)
+                .build(),
+            geospatial_nodes: rstar::RTree::bulk_load(geospatial_nodes),
+            geospatial_edges: rstar::RTree::bulk_load(geospatial_edges),
+            edge_properties,
+        }
+    }
+}
+
+#[test]
+fn network_graph_edge_bearing_between() {
+    let graph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(EdgeId(109783), Length::ZERO, Length::from_meters(20.0))
+            .unwrap(),
+        Bearing::from_degrees(200)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(EdgeId(-109783), Length::ZERO, Length::from_meters(20.0))
+            .unwrap(),
+        Bearing::from_degrees(18)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(
+                EdgeId(5359425),
+                graph.get_edge_length(EdgeId(5359425)).unwrap() - Length::from_meters(1.0),
+                Length::from_meters(20.0)
+            )
+            .unwrap(),
+        Bearing::from_degrees(197)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(EdgeId(-5359425), Length::ZERO, Length::from_meters(20.0))
+            .unwrap(),
+        Bearing::from_degrees(17)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(EdgeId(5104156), Length::ZERO, Length::from_meters(10.0))
+            .unwrap(),
+        Bearing::from_degrees(139)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(
+                EdgeId(5104156),
+                Length::from_meters(15.0),
+                Length::from_meters(5.0)
+            )
+            .unwrap(),
+        Bearing::from_degrees(97)
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_bearing_between(
+                EdgeId(109783),
+                graph.get_edge_length(EdgeId(109783)).unwrap(),
+                Length::from_meters(-20.0)
+            )
+            .unwrap(),
+        Bearing::from_degrees(18)
+    );
+}
+
+#[test]
+fn network_graph_edge_bearing() {
+    let graph = &NETWORK_GRAPH;
+
+    let get_edge_bearing = |edge| {
+        graph
+            .get_edge_bearing_between(edge, Length::ZERO, graph.get_edge_length(edge).unwrap())
+            .unwrap()
+    };
+
+    assert_eq!(
+        get_edge_bearing(EdgeId(-5359425)),
+        Bearing::from_degrees(17)
+    );
+    assert_eq!(
+        get_edge_bearing(EdgeId(5359425)),
+        Bearing::from_degrees(17 + 180)
+    );
+
+    assert_eq!(
+        get_edge_bearing(EdgeId(8717174)),
+        Bearing::from_degrees(106)
+    );
+
+    assert_eq!(
+        get_edge_bearing(EdgeId(5359426)),
+        Bearing::from_degrees(197)
+    );
+
+    assert_eq!(
+        get_edge_bearing(EdgeId(-4925291)),
+        Bearing::from_degrees(286)
+    );
+}
+
+#[test]
+fn network_graph_distance_from_start_vertex() {
+    let graph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(6770340),
+                Coordinate {
+                    lon: 13.462836552352906,
+                    lat: 52.51499534095764,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(0.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(-109783),
+                Coordinate {
+                    lon: 13.462836552352906,
+                    lat: 52.51499534095764,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(1.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(109783),
+                Coordinate {
+                    lon: 13.462836552352906,
+                    lat: 52.51499534095764,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(191.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(4925291),
+                Coordinate {
+                    lon: 13.461116552352905,
+                    lat: 52.51710534095764,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(142.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(-4925291),
+                Coordinate {
+                    lon: 13.461116552352905,
+                    lat: 52.51710534095764,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(1.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(8717174),
+                Coordinate {
+                    lon: 13.461951,
+                    lat: 52.51700,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(57.0)
+    );
+
+    assert_eq!(
+        graph
+            .get_distance_from_start_vertex(
+                EdgeId(-8717174),
+                Coordinate {
+                    lon: 13.461951,
+                    lat: 52.51700,
+                }
+            )
+            .unwrap()
+            .round(),
+        Length::from_meters(80.0)
+    );
+}
+
+#[test]
+fn network_graph_edge_vertices() {
+    let graph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        graph.get_edge_start_vertex(EdgeId(-6770340)).unwrap(),
+        VertexId(102)
+    );
+
+    assert_eq!(
+        graph.vertex_exiting_edges(VertexId(1)).collect::<Vec<_>>(),
+        vec![(EdgeId(16218), VertexId(2))]
+    );
+    assert_eq!(
+        graph.get_edge_start_vertex(EdgeId(16218)).unwrap(),
+        VertexId(1)
+    );
+    assert_eq!(
+        graph.get_edge_end_vertex(EdgeId(16218)).unwrap(),
+        VertexId(2)
+    );
+
+    assert_eq!(
+        graph.vertex_exiting_edges(VertexId(68)).collect::<Vec<_>>(),
+        [
+            (EdgeId(-5359425), VertexId(12)),
+            (EdgeId(-4925291), VertexId(67)),
+            (EdgeId(5359426), VertexId(60)),
+            (EdgeId(8717174), VertexId(95))
+        ]
+    );
+
+    assert_eq!(
+        graph.get_edge_start_vertex(EdgeId(-5359425)).unwrap(),
+        VertexId(68)
+    );
+    assert_eq!(
+        graph.get_edge_end_vertex(EdgeId(-5359425)).unwrap(),
+        VertexId(12)
+    );
+    assert_eq!(
+        graph.get_edge_start_vertex(EdgeId(-5359425)).unwrap(),
+        graph.get_edge_end_vertex(EdgeId(5359425)).unwrap()
+    );
+    assert_eq!(
+        graph.get_edge_end_vertex(EdgeId(-5359425)).unwrap(),
+        graph.get_edge_start_vertex(EdgeId(5359425)).unwrap()
+    );
+}
+
+#[test]
+fn network_graph_edge_coordinates() {
+    let graph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        graph
+            .get_edge_coordinates(EdgeId(5359425))
+            .collect::<Vec<_>>(),
+        [
+            Coordinate {
+                lon: 13.4615934,
+                lat: 52.5180374
+            },
+            Coordinate {
+                lon: 13.4611206,
+                lat: 52.5170944
+            }
+        ]
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_coordinates(EdgeId(8717174))
+            .collect::<Vec<_>>(),
+        [
+            Coordinate {
+                lon: 13.4611206,
+                lat: 52.5170944
+            },
+            Coordinate {
+                lon: 13.4630579,
+                lat: 52.5167465
+            }
+        ]
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_coordinates(EdgeId(-8717174))
+            .collect::<Vec<_>>(),
+        [
+            Coordinate {
+                lon: 13.4630579,
+                lat: 52.5167465
+            },
+            Coordinate {
+                lon: 13.4611206,
+                lat: 52.5170944
+            },
+        ]
+    );
+
+    assert_eq!(
+        graph
+            .get_edge_coordinates(EdgeId(7531948))
+            .collect::<Vec<_>>(),
+        [
+            Coordinate {
+                lon: 13.463911,
+                lat: 52.5148731
+            },
+            Coordinate {
+                lon: 13.4631576,
+                lat: 52.5149491
+            },
+            Coordinate {
+                lon: 13.4628442,
+                lat: 52.5149807
+            }
+        ]
+    );
+}
+
+#[test]
+fn network_graph_nearest_edges() {
+    let graph = &NETWORK_GRAPH;
+
+    let coordinate = Coordinate {
+        lon: 13.461951,
+        lat: 52.51700,
+    };
+
+    const MAX_DISTANCE: Length = Length::from_meters(100.0);
+
+    let edges: Vec<_> = graph
+        .nearest_edges_within_distance(coordinate, MAX_DISTANCE)
+        .map(|(edge, distance)| {
+            assert!(distance <= MAX_DISTANCE);
+            (edge, distance)
+        })
+        .collect();
+    assert!(edges.is_sorted_by_key(|(_, d)| *d));
+
+    // lines with both directions have the same distance, sort by edge ID to make it deterministic
+    let mut edges = edges.into_iter().map(|(e, _)| e).collect::<Vec<_>>();
+    edges.sort_unstable_by_key(|e| e.0);
+
+    assert_eq!(
+        edges,
+        [
+            EdgeId(-8717175),
+            EdgeId(-8717174),
+            EdgeId(-5707439),
+            EdgeId(-5707436),
+            EdgeId(-5707435),
+            EdgeId(-5359426),
+            EdgeId(-5359425),
+            EdgeId(-4925291),
+            EdgeId(4925291),
+            EdgeId(5359425),
+            EdgeId(5359426),
+            EdgeId(5707435),
+            EdgeId(5707436),
+            EdgeId(5707439),
+            EdgeId(8717174),
+            EdgeId(8717175)
+        ]
+    );
+}
+
+#[test]
+fn network_graph_nearest_vertices() {
+    let graph = &NETWORK_GRAPH;
+
+    let node_75_location = Coordinate {
+        lon: 13.459407,
+        lat: 52.5143601,
+    };
+
+    const MAX_DISTANCE: Length = Length::from_meters(90.0);
+
+    let neighbours: Vec<VertexId> = graph
+        .nearest_vertices_within_distance(node_75_location, MAX_DISTANCE)
+        .map(|(vertex, distance)| {
+            assert!(distance <= MAX_DISTANCE);
+            vertex
+        })
+        .collect();
+
+    assert_eq!(
+        neighbours,
+        [
+            VertexId(75),
+            VertexId(140),
+            VertexId(138),
+            VertexId(139),
+            VertexId(59),
+            VertexId(72),
+            VertexId(73),
+            VertexId(74)
+        ]
+    );
+}
+
+#[test]
+fn network_graph_edge_properties() {
+    let graph = &NETWORK_GRAPH;
+
+    let get_exiting_edge_properties = |vertex| {
+        graph
+            .vertex_exiting_edges(vertex)
+            .map(|(edge, vertex_to)| {
+                (
+                    edge,
+                    graph.get_edge_length(edge).unwrap(),
+                    graph.get_edge_frc(edge).unwrap(),
+                    graph.get_edge_fow(edge).unwrap(),
+                    vertex_to,
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let get_entering_edge_properties = |vertex| {
+        graph
+            .vertex_entering_edges(vertex)
+            .map(|(edge, vertex_to)| {
+                (
+                    edge,
+                    graph.get_edge_length(edge).unwrap(),
+                    graph.get_edge_frc(edge).unwrap(),
+                    graph.get_edge_fow(edge).unwrap(),
+                    vertex_to,
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(graph.vertex_entering_edges(VertexId(1)).count(), 0);
+    assert_eq!(
+        get_exiting_edge_properties(VertexId(1)),
+        vec![(
+            EdgeId(16218),
+            Length::from_meters(217.0),
+            Frc::Frc2,
+            Fow::SingleCarriageway,
+            VertexId(2)
+        )]
+    );
+
+    assert_eq!(
+        get_entering_edge_properties(VertexId(126)),
+        vec![
+            (
+                EdgeId(-8323953),
+                Length::from_meters(16.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(127)
+            ),
+            (
+                EdgeId(8323959),
+                Length::from_meters(11.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(129)
+            )
+        ]
+    );
+    assert_eq!(
+        get_exiting_edge_properties(VertexId(126)),
+        vec![
+            (
+                EdgeId(-8323959),
+                Length::from_meters(11.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(129)
+            ),
+            (
+                EdgeId(8323953),
+                Length::from_meters(16.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(127)
+            )
+        ]
+    );
+
+    assert_eq!(
+        get_entering_edge_properties(VertexId(134)),
+        vec![
+            (
+                EdgeId(-8345026),
+                Length::from_meters(31.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(123)
+            ),
+            (
+                EdgeId(8345025),
+                Length::from_meters(199.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(134)
+            )
+        ]
+    );
+    assert_eq!(
+        get_exiting_edge_properties(VertexId(134)),
+        vec![
+            (
+                EdgeId(8345025),
+                Length::from_meters(199.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(134)
+            ),
+            (
+                EdgeId(8345026),
+                Length::from_meters(31.0),
+                Frc::Frc6,
+                Fow::SingleCarriageway,
+                VertexId(123)
+            )
+        ]
+    );
+}

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -1,0 +1,174 @@
+mod graph;
+
+use openlr::{Length, ShortestPath, ShortestPathConfig, shortest_path};
+
+use crate::graph::{EdgeId, NETWORK_GRAPH, NetworkGraph, VertexId};
+
+#[test]
+fn routing_shortest_path_001() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(68),
+            VertexId(68),
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::ZERO,
+            edges: vec![],
+        }
+    );
+}
+
+#[test]
+fn routing_shortest_path_002() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(1),
+            VertexId(2)
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::from_meters(217.0),
+            edges: vec![EdgeId(16218)],
+        }
+    );
+}
+
+#[test]
+fn routing_shortest_path_003() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(2),
+            VertexId(1)
+        ),
+        None
+    );
+}
+
+#[test]
+fn routing_shortest_path_004() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(68),
+            VertexId(20)
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::from_meters(379.0),
+            edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
+        }
+    );
+}
+
+#[test]
+fn routing_shortest_path_005() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(1),
+            VertexId(37)
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::from_meters(753.0),
+            edges: vec![
+                EdgeId(16218),
+                EdgeId(16219),
+                EdgeId(7430347),
+                EdgeId(4232179),
+                EdgeId(961826)
+            ],
+        }
+    );
+}
+
+#[test]
+fn routing_shortest_path_006() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig {
+                max_length: Length::from_meters(752.0),
+                ..Default::default()
+            },
+            graph,
+            VertexId(1),
+            VertexId(37)
+        ),
+        None
+    );
+}
+
+#[test]
+fn routing_shortest_path_007() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(36),
+            VertexId(34)
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::from_meters(16.0),
+            edges: vec![EdgeId(-4232179)],
+        }
+    );
+}
+
+#[test]
+fn routing_shortest_path_008() {
+    let graph: &NetworkGraph = &NETWORK_GRAPH;
+
+    assert_eq!(
+        shortest_path(
+            &ShortestPathConfig::default(),
+            graph,
+            VertexId(1),
+            VertexId(57)
+        )
+        .unwrap(),
+        ShortestPath {
+            length: Length::from_meters(1462.0),
+            edges: vec![
+                EdgeId(16218),
+                EdgeId(16219),
+                EdgeId(7430347),
+                EdgeId(961825),
+                EdgeId(7531950),
+                EdgeId(7531947),
+                EdgeId(7430351),
+                EdgeId(7430360),
+                EdgeId(7430361),
+                EdgeId(7430362),
+                EdgeId(7430348),
+                EdgeId(-244115),
+                EdgeId(-9497548),
+                EdgeId(-9497547),
+                EdgeId(3227046)
+            ],
+        }
+    );
+}


### PR DESCRIPTION
This is the first basic implementation of a Line location decoder, following is a list of main differences (and missing features) when compared to the (Java) reference implementation:

- [Important] Handle start line change when resolving routes (retries)
- Apply non junction node factor to candidate lines (that are not projected).
- Consider previous candidate line when resolving candidate pair scores
- Apply same line degradation to LRP 2 candidate line when resolving candidate pair scores
- Consider line projection when computing checking for min path length
- Decrease offsets if these exceeds route length (but < than 2x route length)