### PR TITLE
Line encoder enhancements

### DIFF
--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -61,7 +61,7 @@ impl<EdgeId: PartialEq> CandidateLinePair<EdgeId> {
     pub fn rating(&self, same_line_degradation: f64) -> RatingScore {
         let mut rating = self.line_lrp1.rating * self.line_lrp2.rating;
 
-        if self.line_lrp1.edge == self.line_lrp2.edge {
+        if self.line_lrp1.edge == self.line_lrp2.edge && !self.line_lrp2.lrp.is_last() {
             rating *= same_line_degradation;
         }
 

--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -400,7 +400,7 @@ fn rate_line<EdgeId: Debug + Copy>(
 
     let ratings = Ratings {
         distance: RatingScore::from(distance),
-        bearing: Bearing::rating_score(line.bearing.rating(&lrp.line.bearing)),
+        bearing: line.bearing.rating_score(&lrp.line.bearing),
         frc: Frc::rating_score(line.frc.rating(&lrp.line.frc)),
         fow: Fow::rating_score(line.fow.rating(&lrp.line.fow)),
     };

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -43,8 +43,15 @@ pub struct EncoderConfig {
 
 impl Default for EncoderConfig {
     fn default() -> Self {
+        // The smaller the max LRP distance the higher the offsets precision, however a small
+        // distance can also negatively affect the decoding step, since having multiple LRPs
+        // on the same line will incur in the same line degradation when rating any possible
+        // route where 2 LRPs are on the same edge.
+        const DEFAULT_MAX_LRP_DISTANCE: Length = Length::from_meters(4000.0);
+        debug_assert!(DEFAULT_MAX_LRP_DISTANCE <= Length::MAX_BINARY_LRP_DISTANCE);
+
         Self {
-            max_lrp_distance: Length::MAX_BINARY_LRP_DISTANCE,
+            max_lrp_distance: DEFAULT_MAX_LRP_DISTANCE,
             bearing_distance: Length::from_meters(20.0),
         }
     }

--- a/src/encoder/resolver.rs
+++ b/src/encoder/resolver.rs
@@ -94,6 +94,7 @@ fn split_lrp<G: DirectedGraph>(
     // long single line was not handled during the shortest route stage when finding intermediates
     debug_assert!(!lrp.point.is_last());
     debug_assert_eq!(lrp.edges.len(), 1);
+    debug_assert!(lrp.projection_coordinate.is_none());
 
     let edge = lrp.edges[0];
     let mut dnp = lrp.point.dnp();
@@ -146,6 +147,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(9044472)],
                     point: Point {
                         coordinate: Coordinate {
@@ -164,6 +166,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -200,6 +203,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-9044470), EdgeId(-9044471), EdgeId(-9044472)],
                     point: Point {
                         coordinate: Coordinate {
@@ -218,6 +222,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -260,6 +265,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7292030)],
                     point: Point {
                         coordinate: Coordinate {
@@ -278,6 +284,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![
                         EdgeId(-7292029),
                         EdgeId(7516886),
@@ -301,6 +308,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -341,6 +349,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(7516884)],
                     point: Point {
                         coordinate: Coordinate {
@@ -359,6 +368,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(7516884), EdgeId(7516885)],
                     point: Point {
                         coordinate: Coordinate {
@@ -377,6 +387,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -420,6 +431,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7516884), EdgeId(-7292029), EdgeId(7516886)],
                     point: Point {
                         coordinate: Coordinate {
@@ -438,6 +450,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(7516883), EdgeId(-7516884), EdgeId(7292030)],
                     point: Point {
                         coordinate: Coordinate {
@@ -456,6 +469,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -499,6 +513,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7516885)],
                     point: Point {
                         coordinate: Coordinate {
@@ -517,6 +532,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7516884)],
                     point: Point {
                         coordinate: Coordinate {
@@ -535,6 +551,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7292029), EdgeId(7516886), EdgeId(7516883)],
                     point: Point {
                         coordinate: Coordinate {
@@ -553,6 +570,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-7516884)],
                     point: Point {
                         coordinate: Coordinate {
@@ -571,6 +589,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -607,6 +626,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(8717174), EdgeId(8717175), EdgeId(109783)],
                     point: Point {
                         coordinate: Coordinate {
@@ -625,6 +645,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -666,6 +687,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![
                         EdgeId(1653344),
                         EdgeId(4997411),
@@ -689,6 +711,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -725,6 +748,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16218)],
                     point: Point {
                         coordinate: Coordinate {
@@ -743,6 +767,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -779,6 +804,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16218), EdgeId(16219)],
                     point: Point {
                         coordinate: Coordinate {
@@ -797,6 +823,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -836,6 +863,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16218)],
                     point: Point {
                         coordinate: Coordinate {
@@ -854,6 +882,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16219)],
                     point: Point {
                         coordinate: Coordinate {
@@ -872,6 +901,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -911,6 +941,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16218)],
                     point: Point {
                         coordinate: Coordinate {
@@ -929,6 +960,10 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: Some(Coordinate {
+                        lon: 13.455676767654381,
+                        lat: 52.5155615984457,
+                    }),
                     edges: vec![EdgeId(16218)],
                     point: Point {
                         coordinate: Coordinate {
@@ -947,6 +982,10 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: Some(Coordinate {
+                        lon: 13.457137508978576,
+                        lat: 52.51540708300186,
+                    }),
                     edges: vec![EdgeId(16218)],
                     point: Point {
                         coordinate: Coordinate {
@@ -960,11 +999,12 @@ mod tests {
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc2,
-                            dnp: Length::from_meters(17.0)
+                            dnp: Length::from_meters(16.346160186372742)
                         })
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(16219)],
                     point: Point {
                         coordinate: Coordinate {
@@ -983,6 +1023,10 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: Some(Coordinate {
+                        lon: 13.458844359049749,
+                        lat: 52.515229693289946,
+                    },),
                     edges: vec![EdgeId(16219)],
                     point: Point {
                         coordinate: Coordinate {
@@ -996,11 +1040,12 @@ mod tests {
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc2,
-                            dnp: Length::from_meters(9.0)
+                            dnp: Length::from_meters(8.884732961834075)
                         })
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {
@@ -1040,6 +1085,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-9044470)],
                     point: Point {
                         coordinate: Coordinate {
@@ -1058,6 +1104,10 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: Some(Coordinate {
+                        lon: 13.459018736929124,
+                        lat: 52.51450982635798,
+                    }),
                     edges: vec![EdgeId(-9044470)],
                     point: Point {
                         coordinate: Coordinate {
@@ -1071,11 +1121,12 @@ mod tests {
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc6,
-                            dnp: Length::from_meters(4.0)
+                            dnp: Length::from_meters(3.523195526723825)
                         })
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-9044471)],
                     point: Point {
                         coordinate: Coordinate {
@@ -1094,6 +1145,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![EdgeId(-9044472)],
                     point: Point {
                         coordinate: Coordinate {
@@ -1112,6 +1164,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
+                    projection_coordinate: None,
                     edges: vec![],
                     point: Point {
                         coordinate: Coordinate {

--- a/src/encoder/resolver.rs
+++ b/src/encoder/resolver.rs
@@ -420,12 +420,7 @@ mod tests {
             lrps,
             [
                 LocRefPoint {
-                    edges: vec![
-                        EdgeId(-7516884),
-                        EdgeId(-7292029),
-                        EdgeId(7516886),
-                        EdgeId(7516883)
-                    ],
+                    edges: vec![EdgeId(-7516884), EdgeId(-7292029), EdgeId(7516886)],
                     point: Point {
                         coordinate: Coordinate {
                             lon: 13.4579134,
@@ -438,25 +433,25 @@ mod tests {
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc6,
-                            dnp: Length::from_meters(101.0)
+                            dnp: Length::from_meters(67.0)
                         })
                     }
                 },
                 LocRefPoint {
-                    edges: vec![EdgeId(-7516884), EdgeId(7292030)],
+                    edges: vec![EdgeId(7516883), EdgeId(-7516884), EdgeId(7292030)],
                     point: Point {
                         coordinate: Coordinate {
-                            lon: 13.4579134,
-                            lat: 52.5186781
+                            lon: 13.4580688,
+                            lat: 52.5189743
                         },
                         line: LineAttributes {
                             frc: Frc::Frc6,
                             fow: Fow::SingleCarriageway,
-                            bearing: Bearing::from_degrees(285),
+                            bearing: Bearing::from_degrees(198),
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc6,
-                            dnp: Length::from_meters(125.0)
+                            dnp: Length::from_meters(159.0)
                         })
                     }
                 },
@@ -540,12 +535,7 @@ mod tests {
                     }
                 },
                 LocRefPoint {
-                    edges: vec![
-                        EdgeId(-7292029),
-                        EdgeId(7516886),
-                        EdgeId(7516883),
-                        EdgeId(-7516884)
-                    ],
+                    edges: vec![EdgeId(-7292029), EdgeId(7516886), EdgeId(7516883)],
                     point: Point {
                         coordinate: Coordinate {
                             lon: 13.4576677,
@@ -558,7 +548,25 @@ mod tests {
                         },
                         path: Some(PathAttributes {
                             lfrcnp: Frc::Frc6,
-                            dnp: Length::from_meters(101.0)
+                            dnp: Length::from_meters(84.0)
+                        })
+                    }
+                },
+                LocRefPoint {
+                    edges: vec![EdgeId(-7516884)],
+                    point: Point {
+                        coordinate: Coordinate {
+                            lon: 13.4579134,
+                            lat: 52.5186781
+                        },
+                        line: LineAttributes {
+                            frc: Frc::Frc6,
+                            fow: Fow::SingleCarriageway,
+                            bearing: Bearing::from_degrees(285),
+                        },
+                        path: Some(PathAttributes {
+                            lfrcnp: Frc::Frc6,
+                            dnp: Length::from_meters(17.0)
                         })
                     }
                 },

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashSet;
+use tracing::debug;
 
 use crate::{DirectedGraph, Length};
 
@@ -46,6 +47,7 @@ pub fn is_path_loop<G: DirectedGraph>(
     let mut seen = FxHashSet::default();
     for v in vertices {
         if !seen.insert(v) {
+            debug!("Found loop at {v:?}: {path:?}");
             return true;
         }
     }

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,3 +1,7 @@
+use std::fmt::Debug;
+
+use tracing::debug;
+
 use crate::graph::path::is_path_connected;
 use crate::{DirectedGraph, Length, LocationError};
 
@@ -19,7 +23,7 @@ pub struct LineLocation<EdgeId> {
     pub neg_offset: Length,
 }
 
-impl<EdgeId: Copy> LineLocation<EdgeId> {
+impl<EdgeId: Copy + Debug> LineLocation<EdgeId> {
     pub fn path_length<G>(&self, graph: &G) -> Length
     where
         G: DirectedGraph<EdgeId = EdgeId>,
@@ -47,6 +51,7 @@ impl<EdgeId: Copy> LineLocation<EdgeId> {
     where
         G: DirectedGraph<EdgeId = EdgeId>,
     {
+        debug!("Trimming {self:?}");
         let path_length = self.path_length(graph);
 
         let Self {


### PR DESCRIPTION
These changes (details in each commit message and comments) aim to improve encoder (and decoder) accuracy, especially when related to how offsets are computed. From the OpenLR paper

> The relative value (or percentage) will then be equally distributed over the available 256 buckets so
that every bucket covers 0.390625% of the LRP length. This method takes the length of a location
into account which results in a better accuracy for shorter locations. Even for shorter locations the
whole bucket range is used and longer locations as no offset value can be greater than 15000 meter
irrespective of the location length.

> If the encoder is forced to generate highly accurate offset values, it is recommended to add an
additional LR-point.

However generating many LRPs may incur in decoding imprecision as it will affect the "same line degradation" step.

With these changes it is possible to encode/decode ~20.000 line locations with a Frechet distance threshold of ~10m