### PR TITLE
Refactor DirectedGraph trait to return non optional data

### DIFF
--- a/src/decoder/candidates.rs
+++ b/src/decoder/candidates.rs
@@ -254,11 +254,11 @@ fn find_candidate_lines_from_nodes<G: DirectedGraph>(
             let bearing = if lrp.is_last() {
                 graph.get_edge_bearing(
                     edge,
-                    graph.get_edge_length(edge)?,
+                    graph.get_edge_length(edge),
                     config.bearing_distance.reverse(),
-                )?
+                )
             } else {
-                graph.get_edge_bearing(edge, Length::ZERO, config.bearing_distance)?
+                graph.get_edge_bearing(edge, Length::ZERO, config.bearing_distance)
             };
 
             let line = ProvisionalCandidateLine {
@@ -266,8 +266,8 @@ fn find_candidate_lines_from_nodes<G: DirectedGraph>(
                 edge,
                 distance_to_lrp,
                 distance_to_projection: None,
-                frc: graph.get_edge_frc(edge)?,
-                fow: graph.get_edge_fow(edge)?,
+                frc: graph.get_edge_frc(edge),
+                fow: graph.get_edge_fow(edge),
                 bearing,
             };
 
@@ -292,22 +292,24 @@ fn append_projected_candidate_lines<G: DirectedGraph>(
         .nearest_edges_within_distance(lrp.coordinate, config.max_node_distance)
         .filter_map(|(edge, distance_to_lrp)| {
             debug_assert!(distance_to_lrp <= config.max_node_distance);
-            let edge_length = graph.get_edge_length(edge)?;
+            let distance_to_projection = graph.get_distance_along_edge(edge, lrp.coordinate);
 
-            let distance_to_projection = graph
-                .get_distance_along_edge(edge, lrp.coordinate)
-                // if distance is 0 or equal to the edge length it would essentially reprensent a
-                // line based on a node, instead of the outcome of the LRP projection
-                .filter(|&d| d.floor() > Length::ZERO && d.ceil() < edge_length)?;
+            // if distance is 0 or equal to the edge length it would essentially reprensent a
+            // line based on a node, instead of the outcome of the LRP projection
+            if distance_to_projection.floor() <= Length::ZERO
+                || distance_to_projection.ceil() >= graph.get_edge_length(edge)
+            {
+                return None;
+            }
 
             let bearing = if lrp.is_last() {
                 graph.get_edge_bearing(
                     edge,
                     distance_to_projection,
                     config.bearing_distance.reverse(),
-                )?
+                )
             } else {
-                graph.get_edge_bearing(edge, distance_to_projection, config.bearing_distance)?
+                graph.get_edge_bearing(edge, distance_to_projection, config.bearing_distance)
             };
 
             let line = ProvisionalCandidateLine {
@@ -315,8 +317,8 @@ fn append_projected_candidate_lines<G: DirectedGraph>(
                 edge,
                 distance_to_lrp,
                 distance_to_projection: Some(distance_to_projection),
-                frc: graph.get_edge_frc(edge)?,
-                fow: graph.get_edge_fow(edge)?,
+                frc: graph.get_edge_frc(edge),
+                fow: graph.get_edge_fow(edge),
                 bearing,
             };
 

--- a/src/decoder/resolver.rs
+++ b/src/decoder/resolver.rs
@@ -136,7 +136,7 @@ fn resolve_single_line_routes<G: DirectedGraph>(
             let edges = if i == 0 { vec![best_edge] } else { vec![] };
 
             let path = Path {
-                length: edges.iter().filter_map(|&e| graph.get_edge_length(e)).sum(),
+                length: edges.iter().map(|&e| graph.get_edge_length(e)).sum(),
                 edges,
             };
 
@@ -185,7 +185,7 @@ fn resolve_candidate_route<G: DirectedGraph>(
         };
 
         let path = Path {
-            length: edges.iter().filter_map(|&e| graph.get_edge_length(e)).sum(),
+            length: edges.iter().map(|&e| graph.get_edge_length(e)).sum(),
             edges,
         };
 
@@ -208,7 +208,7 @@ fn resolve_candidate_route<G: DirectedGraph>(
 
         if !lrp2.is_last() {
             let last_edge = path.edges.pop()?;
-            path.length -= graph.get_edge_length(last_edge)?;
+            path.length -= graph.get_edge_length(last_edge);
         }
 
         debug_assert!(!path.edges.is_empty());
@@ -261,15 +261,11 @@ fn max_route_length<G: DirectedGraph>(
     // shortest path can only stop at distances between real vertices, therefore we need to
     // add the complete length when computing max distance upper bound if the lines were projected
     if line_lrp1.is_projected() {
-        max_distance += graph
-            .get_edge_length(line_lrp1.edge)
-            .unwrap_or(Length::ZERO);
+        max_distance += graph.get_edge_length(line_lrp1.edge);
     }
 
     if line_lrp2.is_projected() || !line_lrp2.lrp.is_last() {
-        max_distance += graph
-            .get_edge_length(line_lrp2.edge)
-            .unwrap_or(Length::ZERO);
+        max_distance += graph.get_edge_length(line_lrp2.edge);
     }
 
     Length::from_meters(max_distance.meters().ceil())

--- a/src/decoder/route.rs
+++ b/src/decoder/route.rs
@@ -106,8 +106,7 @@ impl<EdgeId: Copy> CandidateRoute<EdgeId> {
         } = self.last_candidate();
 
         if let Some(projection) = distance_to_projection {
-            let length = graph.get_edge_length(edge).unwrap_or(Length::ZERO);
-            (length - projection).max(Length::ZERO)
+            (graph.get_edge_length(edge) - projection).max(Length::ZERO)
         } else {
             Length::ZERO
         }

--- a/src/decoder/shortest_path.rs
+++ b/src/decoder/shortest_path.rs
@@ -17,11 +17,11 @@ pub fn shortest_path<G: DirectedGraph>(
 ) -> Option<Path<G::EdgeId>> {
     trace!(
         "Computing shortest path {origin:?} {:?} -> {destination:?} {:?}",
-        graph.get_edge_start_vertex(origin)?,
-        graph.get_edge_end_vertex(destination)?
+        graph.get_edge_start_vertex(origin),
+        graph.get_edge_end_vertex(destination)
     );
 
-    let origin_length = graph.get_edge_length(origin)?;
+    let origin_length = graph.get_edge_length(origin);
     let mut shortest_distances = FxHashMap::from_iter([(origin, origin_length)]);
     let mut previous_map: FxHashMap<G::EdgeId, G::EdgeId> = FxHashMap::default();
     let mut heap = RadixHeapMap::from_iter([(Reverse(origin_length), origin)]);
@@ -45,14 +45,12 @@ pub fn shortest_path<G: DirectedGraph>(
         }
 
         let exiting_edges = graph
-            .get_edge_end_vertex(h_edge)
-            .into_iter()
-            .flat_map(|v| graph.vertex_exiting_edges(v))
+            .vertex_exiting_edges(graph.get_edge_end_vertex(h_edge))
             .filter(|&(e, _)| !graph.is_turn_restricted(h_edge, e));
 
         for (edge, _) in exiting_edges {
-            let distance = h_distance + graph.get_edge_length(edge)?;
-            let frc = graph.get_edge_frc(edge)?;
+            let distance = h_distance + graph.get_edge_length(edge);
+            let frc = graph.get_edge_frc(edge);
 
             if distance > max_length {
                 trace!("Element distance too far: {edge:?} {distance} > {max_length}");
@@ -111,16 +109,6 @@ mod tests {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(
-            shortest_path(graph, EdgeId(0), EdgeId(i64::MAX), Frc::Frc7, Length::MAX),
-            None
-        );
-    }
-
-    #[test]
-    fn decoder_shortest_path_003() {
-        let graph: &NetworkGraph = &NETWORK_GRAPH;
-
-        assert_eq!(
             shortest_path(
                 graph,
                 EdgeId(8717174),
@@ -137,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn decoder_shortest_path_004() {
+    fn decoder_shortest_path_003() {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(
@@ -156,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn decoder_shortest_path_005() {
+    fn decoder_shortest_path_004() {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(
@@ -172,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn decoder_shortest_path_006() {
+    fn decoder_shortest_path_005() {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(
@@ -192,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn decoder_shortest_path_007() {
+    fn decoder_shortest_path_006() {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(
@@ -228,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn decoder_shortest_path_008() {
+    fn decoder_shortest_path_007() {
         let graph: &NetworkGraph = &NETWORK_GRAPH;
 
         assert_eq!(

--- a/src/encoder/expansion.rs
+++ b/src/encoder/expansion.rs
@@ -47,10 +47,8 @@ fn edge_forward_expansion<G: DirectedGraph>(
     let mut edge = line.path[line.path.len() - 1];
     let mut offset = line.neg_offset;
 
-    while let Some(vertex) = graph
-        .get_edge_end_vertex(edge)
-        .filter(|&v| !is_node_valid(graph, v))
-    {
+    while !is_node_valid(graph, graph.get_edge_end_vertex(edge)) {
+        let vertex = graph.get_edge_end_vertex(edge);
         let candidates = graph.vertex_exiting_edges(vertex).map(|(e, _)| e);
 
         match resolve_edge_expansion(config, graph, line, offset, &expansion, edge, candidates) {
@@ -90,10 +88,8 @@ fn edge_backward_expansion<G: DirectedGraph>(
     let mut edge = line.path[0];
     let mut offset = line.pos_offset;
 
-    while let Some(vertex) = graph
-        .get_edge_start_vertex(edge)
-        .filter(|&v| !is_node_valid(graph, v))
-    {
+    while !is_node_valid(graph, graph.get_edge_start_vertex(edge)) {
+        let vertex = graph.get_edge_start_vertex(edge);
         let candidates = graph.vertex_entering_edges(vertex).map(|(e, _)| e);
 
         match resolve_edge_expansion(config, graph, line, offset, &expansion, edge, candidates) {
@@ -140,7 +136,7 @@ where
     I: IntoIterator<Item = G::EdgeId>,
 {
     let candidate = select_edge_expansion_candidate(graph, edge, candidates)?;
-    let length = graph.get_edge_length(candidate).unwrap_or(Length::MAX);
+    let length = graph.get_edge_length(candidate);
 
     // including the edge in the expansion must not exceed the max distance or form a loop
     if offset + length > config.max_lrp_distance
@@ -184,10 +180,8 @@ where
     } else if is_e2_opposite && !is_e1_opposite {
         return Some(e1);
     } else if is_e1_opposite && is_e2_opposite {
-        let length = graph.get_edge_length(edge)?;
-
-        let is_length_similar =
-            |e| Some((length - graph.get_edge_length(e)?).meters().abs() <= 1.0);
+        let length = graph.get_edge_length(edge);
+        let is_length_similar = |e| Some((length - graph.get_edge_length(e)).meters().abs() <= 1.0);
 
         match (is_length_similar(e1)?, is_length_similar(e2)?) {
             (false, true) => return Some(e1),

--- a/src/encoder/shortest_path.rs
+++ b/src/encoder/shortest_path.rs
@@ -88,12 +88,8 @@ pub fn shortest_path_location<G: DirectedGraph>(
         }));
     }
 
-    let max_length = location
-        .iter()
-        .filter_map(|&e| graph.get_edge_length(e))
-        .sum();
-
-    let origin_length = graph.get_edge_length(origin).unwrap_or(Length::MAX);
+    let max_length = location.iter().map(|&e| graph.get_edge_length(e)).sum();
+    let origin_length = graph.get_edge_length(origin);
 
     let mut shortest_distances = FxHashMap::from_iter([(origin, origin_length)]);
     let mut previous_map: FxHashMap<G::EdgeId, G::EdgeId> = FxHashMap::default();
@@ -143,14 +139,11 @@ pub fn shortest_path_location<G: DirectedGraph>(
         }
 
         let exiting_edges = graph
-            .get_edge_end_vertex(h_edge)
-            .into_iter()
-            .flat_map(|v| graph.vertex_exiting_edges(v))
+            .vertex_exiting_edges(graph.get_edge_end_vertex(h_edge))
             .filter(|&(e, _)| !graph.is_turn_restricted(h_edge, e));
 
         for (edge, _) in exiting_edges {
-            let edge_length = graph.get_edge_length(edge).unwrap_or(Length::MAX);
-            let distance = h_distance + edge_length;
+            let distance = h_distance + graph.get_edge_length(edge);
 
             if distance > max_length {
                 continue;
@@ -311,7 +304,7 @@ impl<'a, G: DirectedGraph> Intermediator<'a, G> {
             // found in the location.
             if edge == self.location[0] {
                 return Some(self.last_edge_index);
-            } else if is_node_valid(self.graph, self.graph.get_edge_start_vertex(edge)?) {
+            } else if is_node_valid(self.graph, self.graph.get_edge_start_vertex(edge)) {
                 return self.location.iter().position(|&e| e == edge);
             }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,37 +13,30 @@ pub trait DirectedGraph {
     type EdgeId: Debug + Copy + Ord + Hash;
 
     /// Gets the vertex coordinate.
-    /// Returns None if the vertex doesn't belong to the graph.
-    fn get_vertex_coordinate(&self, vertex: Self::VertexId) -> Option<Coordinate>;
+    fn get_vertex_coordinate(&self, vertex: Self::VertexId) -> Coordinate;
 
     /// Gets the start vertex of the directed edge.
-    /// Returns None if the edge doesn't belong to the graph.
-    fn get_edge_start_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId>;
+    fn get_edge_start_vertex(&self, edge: Self::EdgeId) -> Self::VertexId;
 
     /// Gets the end vertex of the directed edge.
-    /// Returns None if the edge doesn't belong to the graph.
-    fn get_edge_end_vertex(&self, edge: Self::EdgeId) -> Option<Self::VertexId>;
+    fn get_edge_end_vertex(&self, edge: Self::EdgeId) -> Self::VertexId;
 
     /// Gets the total length of the directed edge.
-    /// Returns None if the edge doesn't belong to the graph.
-    fn get_edge_length(&self, edge: Self::EdgeId) -> Option<Length>;
+    fn get_edge_length(&self, edge: Self::EdgeId) -> Length;
 
     /// Gets the Functional Road Class (FRC) of the directed edge.
-    /// Returns None if the edge doesn't belong to the graph.
-    fn get_edge_frc(&self, edge: Self::EdgeId) -> Option<Frc>;
+    fn get_edge_frc(&self, edge: Self::EdgeId) -> Frc;
 
     /// Gets the Form of Way (FOW) of the directed edge.
-    /// Returns None if the edge doesn't belong to the graph.
-    fn get_edge_fow(&self, edge: Self::EdgeId) -> Option<Fow>;
+    fn get_edge_fow(&self, edge: Self::EdgeId) -> Fow;
 
     /// Gets an iterator over all the coordinates of the directed edge.
     /// The coordinates will be sorted from the first vertex to the last vertex.
-    /// Returns an empty iterator if the edge doesn't belong to the graph.
+    /// The iterator cannot be empty, every edge should have at least 2 coordinates.
     fn get_edge_coordinates(&self, edge: Self::EdgeId) -> impl Iterator<Item = Coordinate>;
 
     /// Gets an iterator over all the outgoing edges from the given vertex.
     /// For each edge returns the edge ID and the edge end vertex.
-    /// Returns an empty iterator if the vertex doesn't belong to the graph.
     fn vertex_exiting_edges(
         &self,
         vertex: Self::VertexId,
@@ -51,7 +44,6 @@ pub trait DirectedGraph {
 
     /// Gets an iterator over all the incoming edges to the given vertex.
     /// For each edge returns the edge ID and the edge start vertex.
-    /// Returns an empty iterator if the vertex doesn't belong to the graph.
     fn vertex_entering_edges(
         &self,
         vertex: Self::VertexId,
@@ -60,7 +52,7 @@ pub trait DirectedGraph {
     /// Gets an iterator over all the vertices that are within a max distance from the coordinate.
     /// For each vertex also returns the distance from the coordinate.
     /// Vertices must be returned sorted by their distance to the coordinate.
-    /// Returns an empty iterator if no vertex could be found within distance.
+    /// Returns an empty iterator if no vertex can be found within max distance.
     fn nearest_vertices_within_distance(
         &self,
         coordinate: Coordinate,
@@ -70,7 +62,7 @@ pub trait DirectedGraph {
     /// Gets an iterator over all the edges that are within a max distance from the coordinate.
     /// For each edges also returns the distance from the coordinate.
     /// Edges must be returned sorted by their distance to the coordinate.
-    /// Returns an empty iterator if no vertex could be found within distance.
+    /// Returns an empty iterator if no vertex can be found within max distance.
     fn nearest_edges_within_distance(
         &self,
         coordinate: Coordinate,
@@ -79,38 +71,31 @@ pub trait DirectedGraph {
 
     /// Gets the distance of the projected coordinate to the start vertex of the edge when following
     /// the edge coordinates.
-    /// Returns None if the edge doesn't belong to the graph or if the coordinate cannot be
-    /// projected.
+    /// The returned length should be clamped between 0 and the edge length.
     ///
     /// The projection point shall be that coordinate on the line with the smallest distance between
     /// the line and the given coordinate.
-    fn get_distance_along_edge(&self, edge: Self::EdgeId, coordinate: Coordinate)
-    -> Option<Length>;
+    fn get_distance_along_edge(&self, edge: Self::EdgeId, coordinate: Coordinate) -> Length;
 
     /// Gets the coordinate along the edge geometry which is at the given distance from the edge
-    /// start vertex. Returns None if the edge doesn't belong to the graph or if the coordinate
-    /// cannot be found.
+    /// start vertex.
     ///
     /// The distance is clamped within the edge length, therefore for distances lower of equal to
     /// zero the edge start vertex coordinate will be returned and for distances greater or equal to
     /// the edge length the edge end vertex coordinate will be returned.
-    fn get_coordinate_along_edge(&self, edge: Self::EdgeId, distance: Length)
-    -> Option<Coordinate>;
+    fn get_coordinate_along_edge(&self, edge: Self::EdgeId, distance: Length) -> Coordinate;
 
     /// Gets the bearing of a subsection A-B of the edge that goes from the coordinate (A) at the
     /// given distance from the start vertex, and the coordinate (B) that is at the given distance
     /// from A. The segment length can be negative.
-    /// Returns None if the edge doesn't belong to the graph or if the segment cannot be
-    /// constructed.
     fn get_edge_bearing(
         &self,
         edge: Self::EdgeId,
         distance_from_start: Length,
         segment_length: Length,
-    ) -> Option<Bearing>;
+    ) -> Bearing;
 
     /// Returns true if turning from the start edge to the end edge is not allowed.
-    /// If any of the given edges doesn't belog to the path returns true.
     fn is_turn_restricted(&self, start: Self::EdgeId, end: Self::EdgeId) -> bool;
 
     /// Returns the total number of edges that are connected to the vertex, that is, the sum of the
@@ -136,6 +121,7 @@ pub mod path;
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(clippy::panic)]
     #![allow(clippy::disallowed_types)]
 
     mod geojson;

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -29,17 +29,14 @@ pub fn is_path_loop<G: DirectedGraph>(
         let first = path
             .first()
             .filter(|_| pos_offset.is_zero())
-            .and_then(|&e| graph.get_edge_start_vertex(e));
+            .map(|&e| graph.get_edge_start_vertex(e));
 
-        let middle = path
-            .iter()
-            .skip(1)
-            .flat_map(|&e| graph.get_edge_start_vertex(e));
+        let middle = path.iter().skip(1).map(|&e| graph.get_edge_start_vertex(e));
 
         let last = path
             .last()
             .filter(|_| neg_offset.is_zero())
-            .and_then(|&e| graph.get_edge_end_vertex(e));
+            .map(|&e| graph.get_edge_end_vertex(e));
 
         first.into_iter().chain(middle).chain(last)
     };
@@ -65,11 +62,12 @@ pub fn is_path_connected<G: DirectedGraph>(graph: &G, path: &[G::EdgeId]) -> boo
             return false;
         }
 
-        match graph.get_edge_end_vertex(e1) {
-            Some(v) if !graph.vertex_exiting_edges(v).any(|(e, _)| e == e2) => return false,
-            None => return false,
-            Some(_) => (),
-        };
+        if !graph
+            .vertex_exiting_edges(graph.get_edge_end_vertex(e1))
+            .any(|(e, _)| e == e2)
+        {
+            return false;
+        }
     }
 
     true

--- a/src/location.rs
+++ b/src/location.rs
@@ -28,10 +28,7 @@ impl<EdgeId: Copy + Debug> LineLocation<EdgeId> {
     where
         G: DirectedGraph<EdgeId = EdgeId>,
     {
-        self.path
-            .iter()
-            .filter_map(|&e| graph.get_edge_length(e))
-            .sum()
+        self.path.iter().map(|&e| graph.get_edge_length(e)).sum()
     }
 
     /// Construct a valid Line location from the path trimed by its offsets.
@@ -138,7 +135,7 @@ where
         .scan(Length::ZERO, |length, (i, edge)| {
             let current_length = *length;
             if current_length <= offset {
-                *length += graph.get_edge_length(edge).unwrap_or(Length::ZERO);
+                *length += graph.get_edge_length(edge);
                 Some((i, current_length))
             } else {
                 None


### PR DESCRIPTION
The input to any `DirectedGraph` is originated from the output of other methods of the same trait. This output must be valid, and therefore we can assume that all the information can be computed without any error. If this is not the case it should be considered as a fatal error.

This allows to simplify the trait and the OpenLR implementation as well.